### PR TITLE
Fix a few grammatical mistakes

### DIFF
--- a/components/landing/eden.vue
+++ b/components/landing/eden.vue
@@ -10,7 +10,7 @@
         <p class="leading-relaxed">
             With
             <a class="text-pink-500 underline" href="/collections/eden">Eden</a
-            >, you fully get type-safe client on both client and server
+            >, you get fully type-safe client on both client and server
         </p>
 
         <section class="flex flex-col lg:flex-row justify-center items-start gap-6 mt-4 mb-12 md:mb-4 w-full">

--- a/components/landing/familiar.vue
+++ b/components/landing/familiar.vue
@@ -26,12 +26,12 @@ new Elysia()
                     Familiar syntax that clicks
                 </h2>
                 <p>
-                    Picking up from Node.js, Elysia is easy to get start
+                    Picking up from Node.js, Elysia is easy to get started
                     with as it has familar syntax like most of the framework.
                 </p>
                 <p>
                     Also with great support of TypeScript, you will have the
-                    best experience with infers type and autocomplete.
+                    best experience with inferred types and autocomplete.
                 </p>
                 <a
                     class="text-base text-pink-500 mt-2"

--- a/components/landing/get-start.vue
+++ b/components/landing/get-start.vue
@@ -5,12 +5,12 @@
         <h2
             class="text-3xl md:text-4xl text-gray-700 dark:text-gray-100 font-semibold text-center"
         >
-            It's easy to get start
+            It's easy to get started 
         </h2>
 
         <p class="text-xl text-center">
             The future of JavaScript <span class="text-pink-500">await</span>,
-            it will worth your time,
+            it will be worth your time,
             <span class="text-pink-500">promise</span>.
         </p>
 

--- a/components/landing/typescript.vue
+++ b/components/landing/typescript.vue
@@ -5,11 +5,11 @@
         <h2
             class="text-3xl md:text-4xl text-gray-700 dark:text-gray-100 font-semibold text-center mb-4"
         >
-            First-class TypeScript Supports
+            First-class TypeScript Support
         </h2>
         <p class="leading-relaxed">
-            Instead of writing type, Elysia understands what you want and
-            automatically infers the type from your code.
+            Instead of writing types, Elysia understands what you want and
+            automatically infers the types from your code.
         </p>
 
         <div


### PR DESCRIPTION
I fixed a few grammatical mistakes that I found on the site.
Also, some of the wording is a bit weird or doesn't make much sense, for example:
> Picking up from Node.js, Elysia is easy to get started with as it has **<ins>familar syntax like most of the framework</ins>**.

Not sure what the highlighted part is supposed to mean

> Familiar Syntax like Express.

Shouldn't it be "Similar syntax to Express" instead?

I could try rewriting some of these paragraphs to make them clearer if you'd like to.