### PR TITLE
Fixed sidebar typos

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
         ],
         sidebar: [
             {
-                text: 'Getting Start',
+                text: 'Getting Started',
                 collapsible: true,
                 items: [
                     {
@@ -102,7 +102,7 @@ export default defineConfig({
                 ]
             },
             {
-                text: 'Concept',
+                text: 'Concepts',
                 collapsible: true,
                 items: [
                     {


### PR DESCRIPTION
I just fixed some minor issues on the sidebar.

Made some of the subheadings plural to make them consistent such as

> Core Concepts
> Collections

Made the `Getting Start` subheading as `Getting Started`