### PR TITLE
🔧 fix: blog card bg color on focus

### DIFF
--- a/components/blog/Landing.vue
+++ b/components/blog/Landing.vue
@@ -12,7 +12,7 @@
     <main class="flex flex-col max-w-xl gap-4 w-full mx-auto mt-8">
         <a
             v-for="blog in props.blogs"
-            class="px-4 py-2 rounded-lg hover:bg-gray-50 focus:bg-gray-50 dark:hover:bg-gray-700 dark:focus:bg-gray-50 transition-colors cursor-pointer"
+            class="px-4 py-2 rounded-lg hover:bg-gray-50 focus:bg-gray-50 dark:hover:bg-gray-700 dark:focus:bg-gray-700 transition-colors cursor-pointer"
             :href="blog.href"
         >
             <article class="flex flex-col gap-2">


### PR DESCRIPTION
the blog card's bg color currently turns `gray-50` even on dark mode which makes it unreadable, changed it to `gray-700` as I think that was the intended behavior (didn't make a pr the traditional way as it was a very small change)

![image](https://user-images.githubusercontent.com/68690233/216800324-4145c810-d972-4d1d-87e0-0220121d0653.png)
