### PR TITLE
🔧 fix: default param on destructuring example

### DIFF
--- a/docs/concept/plugin.md
+++ b/docs/concept/plugin.md
@@ -26,7 +26,7 @@ You can customize plugin by creating function to return callback which accepts E
 import { Elysia } from 'elysia'
 
 const plugin = ({
-    prefix: '/v1'
+    prefix = '/v1'
 }) => (app: Elysia) => app
     .get(`/${prefix}/hi`, () => 'Hi')
 


### PR DESCRIPTION
Fix example showing custom plugin parameter destructuring.

By using `:` we are renaming variable `prefix` to `/v1` that won't work.. so fixes this