### PR TITLE
🔧 fix: link to documentation repository

### DIFF
--- a/docs/collections/plugins.md
+++ b/docs/collections/plugins.md
@@ -28,4 +28,4 @@ That's why Elysia is creating pre-built common pattern plugin for convinient usa
 - [OAuth2](https://github.com/bogeychan/elysia-oauth2) - handle OAuth 2.0 authorization code flow
 
 ---
-If you have plugin written for Elysia, feels free to share you plugin by creating PR to [documentation repo](https://github.com/elysiajs/elysia-docs).
+If you have plugin written for Elysia, feels free to share you plugin by creating PR to [documentation repo](https://github.com/elysiajs/documentation).


### PR DESCRIPTION
Fixes link to documentation repository in a plugin section