### PR TITLE
Update swagger.md typo

### DIFF
--- a/docs/plugins/swagger.md
+++ b/docs/plugins/swagger.md
@@ -86,7 +86,7 @@ import { swagger } from '@elysiajs/swagger'
 
 new Elysia()
     .use(swagger({
-        swagger: {
+        documentation: {
             info: {
                 title: 'Elysia Documentation',
                 version: '1.0.0'


### PR DESCRIPTION
Swagger plugin field key should be `documentation` instead of `swagger`:

https://github.com/elysiajs/elysia-swagger/blob/8fa26e6a72e21b2ce6fbec37e9f8c93af791f296/src/index.ts#L19