### PR TITLE
fix: added a word in the example

### DIFF
--- a/docs/patterns/method-chaining.md
+++ b/docs/patterns/method-chaining.md
@@ -23,7 +23,7 @@ Using method chaining will help save that new type refernce.
 
 For example:
 ```typescript
-const = new Elysia()
+const app = new Elysia()
     .state('build', 1)
     // Store is strictly typed
     .get('/', ({ store: { build } }) => build)


### PR DESCRIPTION
The name of the variable was missing in the code example so I added it.