### PR TITLE
added missing "s"

### DIFF
--- a/components/landing/heading.vue
+++ b/components/landing/heading.vue
@@ -64,7 +64,7 @@
                         </a>
                     </div>
                     <small class="text-white text-lg opacity-65"
-                        >ps. it take &lt; 30 seconds to start</small
+                        >ps. it takes &lt; 30 seconds to start</small
                     >
                 </section>
                 <section


### PR DESCRIPTION
I noticed the "ps. it take < 30 seconds to start" section under the "Get Started" button was missing an "s", thought I'd submit a quick PR to fix it.

Thanks!