### PR TITLE
Fix wording in Concepts section

### DIFF
--- a/docs/concept/derive.md
+++ b/docs/concept/derive.md
@@ -15,7 +15,7 @@ head:
 ---
 
 # Derive
-Just like state and decorate, derive allows you to customize `Context` based on existing `Context` as `Context.store`.
+Just like _state_ and _decorate_, derive allows you to customize `Context` based on existing `Context` as `Context.store`.
 
 This is useful when you to need to create a value based on an existing value reactively.
 

--- a/docs/concept/guard.md
+++ b/docs/concept/guard.md
@@ -18,10 +18,10 @@ head:
 # Guard
 Suppose you have many shared local hooks.
 
-Instead of writing duplicated hook, you can define a shared hook scope using `guard`.
+Instead of duplicating an existing hook, you can define a shared hook scope using `guard`.
 
 ---
-**Guard** let you to inject multiple life-cycle event into multiple routes at once. Guard is useful when you have duplicated life-cycle in the multiple route, for example. logging, schema validation, or error handling.
+**Guard** lets you inject multiple life-cycle events into multiple routes at once. Guard is useful when you have listen to same life-cycle events in the multiple routes, for example: logging, schema validation, or error handling.
 
 To encapsulate all hooks into the scope, instead of writing:
 ```typescript

--- a/docs/concept/handler.md
+++ b/docs/concept/handler.md
@@ -15,7 +15,7 @@ head:
 ---
 
 # Handler
-For routing is to tell which function to return a response to.
+To route is to tell which function should return a response.
 
 The function for returning a Response is `Handler`.
 
@@ -80,7 +80,7 @@ new Response(JSON.stringify({
 })
 ```
 
-But Elysia handle that for you.
+But Elysia handles that for you.
 
 You simply return an object, and Elysia will map your value to a correct response for you.
 ```typescript

--- a/docs/concept/middleware.md
+++ b/docs/concept/middleware.md
@@ -15,18 +15,14 @@ head:
 ---
 
 # Middleware
-Elysia has Life Cycle event support which you get called on a specific event.
+Elysia supports Life Cycle events, which trigger at specific moments.
 
-Middleware or Hook is an event listener to "hook", and listen to those events cycling around.
+A _Middleware_ or _Hook_ acts as an event listener, allowing you to "hook" into these events. This Hook capability enables you to modify data as it moves through the data pipeline.
 
-Hook allows you to transform data running through the data pipeline.
-
-Whether you want to create a custom body parser, return a custom response based on your handler, or define a custom function for guarding authentication.
-
-With the hook, you can customize Elysia to its fullest potential.
+Whether you aim to implement a custom body parser, generate a tailored response based on your handler, or set up an authentication guard, the Hook empowers you to harness the full potential of Elysia.
 
 ## Life Cycle
-The life cycle in Elysia consists of:
+The life cycle events in Elysia consists of:
 - Start: setup some requirement before the server start serving
 (Start Loop)
 - Request: get notified of every new request

--- a/docs/concept/numeric.md
+++ b/docs/concept/numeric.md
@@ -17,7 +17,7 @@ head:
 
 # Numeric
 
-Sometime you might found yourself in need of numeric string like extracting path parameter, but it's typed as string and need to be convert to number.
+Sometime you might find yourself in need of numeric string like extracting path parameter, but it's typed as string and need to be convert to number.
 
 Using Elysia's `transform` life-cycle, you can manually parse number to string and reuse the transform function in other handler as well.
 


### PR DESCRIPTION
Fixed some small wording errors and reworked few sentences. This is to improve readability and provide more seamless introduction to the framework.