### PR TITLE
Fix syntax

### DIFF
--- a/docs/plugins/eden/treaty.md
+++ b/docs/plugins/eden/treaty.md
@@ -226,10 +226,8 @@ const app = new Elysia()
         message(ws, message) {
             ws.send(message)
         },
-        schema: {
-            body: t.String(),
-            response: t.String()
-        }
+        body: t.String(),
+        response: t.String()
     })
     .listen(8080)
 


### PR DESCRIPTION
There is incorrect syntax used in `docs/plugins/eden/treaty.md`