### PR TITLE
fix: WebSocket URL

### DIFF
--- a/docs/concept/config.md
+++ b/docs/concept/config.md
@@ -52,7 +52,7 @@ new Elysia()
 ```
 
 ::: tip
-For providing WebSocket, please use [`@elysiajs/websocket`](https://github.com/elysiajs/elysia-websocket)
+For providing WebSocket, please use [`WebSocket`](/patterns/websocket)
 :::
 
 ## Custom Port


### PR DESCRIPTION
I was navigating `concept/config` on the docs and the URL for the WebSocket module points to the old URL [@elysiajs/websocket](https://github.com/elysiajs/elysia-websocket)

This PR just changes the link to point to the documentation itself