### PR TITLE
🔧 fix: invaild imports

### DIFF
--- a/docs/patterns/file-upload.md
+++ b/docs/patterns/file-upload.md
@@ -18,7 +18,7 @@ head:
 Elysia handles attachment of `multipart/form-data` to `Context.body` by default.
 
 ```typescript
-import { Elysia, t } from '../src'
+import { Elysia, t } from 'elysia'
 
 const app = new Elysia()
 	.post('/single', ({ body: { file } }) => file, {
@@ -35,7 +35,7 @@ You can use `t.File`, and `t.Files` to strictly validate files:
 - `t.Files`: validate multiple files (array) as `Blob[]`
 
 ```typescript
-import { Elysia, t } from '../src'
+import { Elysia, t } from 'elysia'
 
 const app = new Elysia()
 	.post(

--- a/docs/patterns/lazy-loading-module.md
+++ b/docs/patterns/lazy-loading-module.md
@@ -81,7 +81,7 @@ Using module lazy-loading is recommended when the module is computationally heav
 In a test environment, you can use `await app.modules` to wait for deferred and lazy-loading modules.
 
 ```typescript
-import { Elysia } from '../src'
+import { Elysia } from 'elysia'
 
 import { describe, expect, it } from 'bun:test'
 


### PR DESCRIPTION
While trying to use File upload, I came across these invalid imports, which don't work with the prod version. This PR changes those from `../src` → `elysiajs`

Thanks!