### PR TITLE
🔧 fix: eden docs container display

### DIFF
--- a/docs/plugins/eden/fn.md
+++ b/docs/plugins/eden/fn.md
@@ -40,7 +40,7 @@ const fn = edenFn<App>('http://localhost:8080')
 const data = await fn.sum(6, 9)
 ```
 
-Elysia Fn uses JavaScript's Proxy to capture object properties and parameters, to create batched requests to the server to handle, and returns the value across the network. 
+Elysia Fn uses JavaScript's Proxy to capture object properties and parameters, to create batched requests to the server to handle, and returns the value across the network.
 
 Elysia Fn extends [superjson](https://github.com/blitz-js/superjson), allowing native type in JavaScript like `Error`, `Map`, `Set`, and `undefined` to parse across JSON data.
 
@@ -53,7 +53,6 @@ As for naming convention, we will refers to Elysia Fn and Eden Fn as:
 
 - Elysia Fn: Exposed functions on Elysia server
 - Eden Fn: A client to use Elysia Fn
-:::
 
 ## Security
 You can limit allow or deny scopes of the function, check for the authorization header and other headers' fields, validate parameters, or limit keys access programmatically using `permission` function.

--- a/docs/plugins/eden/overview.md
+++ b/docs/plugins/eden/overview.md
@@ -15,7 +15,7 @@ head:
 ---
 
 # Eden
-Eden is a fetch client for an Elysia server with **end-to-end type safety** using only TypeScript's type inference instead of code generation. 
+Eden is a fetch client for an Elysia server with **end-to-end type safety** using only TypeScript's type inference instead of code generation.
 
 Allowing you to sync client and server types effortlessly, weighing less than 2KB.
 
@@ -92,6 +92,6 @@ Using Eden Treaty with a complex type and lot of routes (more than 500 routes pe
 
 Eden Fetch is an alternative and solution for fastest type inference possible while providing full type support like Eden Treaty.
 
-::: note
+::: tip NOTE
 Unlike Eden Treaty, Eden Fetch doesn't provide Web Socket implementation for Elysia server
 :::


### PR DESCRIPTION
- Removed not used ":::" from eden list
- Fixed display of container on eden docs page

Before / After:
----
<img width="738" alt="Screenshot 2023-09-13 at 00 35 53" src="https://github.com/elysiajs/documentation/assets/36774784/115c0758-5291-40a2-a0da-1373add67095">
