### PR TITLE
Fix cors configuration key in documentation

### DIFF
--- a/docs/plugins/cors.md
+++ b/docs/plugins/cors.md
@@ -70,7 +70,7 @@ Value can be one of the following:
     - eg: `['GET', 'PUT', 'POST']`
 
 ---
-### allowHeaders
+### allowedHeaders
 @default `*`
 
 Allowed headers for an incoming request.


### PR DESCRIPTION
The correct key is allowedHeaders not allowHeaders. 