### PR TITLE
slightly better contrast ratio of text in light mode for landing page

### DIFF
--- a/components/midori/community.vue
+++ b/components/midori/community.vue
@@ -10,15 +10,15 @@
                     Can't find what you're looking for?
                 </h2>
                 <h2
-                    class="text-5xl leading-tight font-semibold text-gray-400 mb-4 bg-clip-text text-transparent bg-gradient-to-tl from-fuchsia-500 to-blue-500"
+                    class="text-5xl leading-tight font-semibold text-gray-400 mb-4 bg-clip-text text-transparent bg-gradient-to-tl from-fuchsia-600 to-blue-600 dark:from-fuchsia-500 dark:to-blue-500"
                 >
                     Join the community
                 </h2>
             </header>
-            <p class="text-xl text-gray-400 w-full max-w-lg mb-4">
+            <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4">
                 Elysia is one of the biggest communities for Bun first web frameworks.
             </p>
-            <p class="text-xl text-gray-400 w-full max-w-lg">
+            <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg">
                 You can ask your questions / propose a new feature / file a bug with our community and mainters.
             </p>
         </section>

--- a/components/midori/e2e-type-safety.vue
+++ b/components/midori/e2e-type-safety.vue
@@ -35,17 +35,17 @@ await eden.user.age.patch({
     <section
         class="flex flex-col justify-center items-center w-full max-w-6xl mx-auto"
     >
-        <h3 class="text-2xl mr-auto md:mx-auto font-medium text-gray-400">
+        <h3 class="text-2xl mr-auto md:mx-auto font-medium text-gray-500 dark:text-gray-400">
             Introducing
         </h3>
         <h2
-            class="text-5xl md:text-6xl font-bold !leading-tight text-transparent bg-clip-text bg-gradient-to-r from-sky-300 to-indigo-400 mt-2 mb-4 mr-auto md:mx-auto"
+            class="text-5xl md:text-6xl font-bold !leading-tight text-transparent bg-clip-text bg-gradient-to-r from-sky-400 to-indigo-500 dark:from-sky-300 dark:to-indigo-400 mt-2 mb-4 mr-auto md:mx-auto"
         >
             End–to-End Type Safety
         </h2>
 
         <p
-            class="text-xl md:text-2xl leading-relaxed text-gray-400 text-left md:text-center w-full max-w-2xl"
+            class="text-xl md:text-2xl leading-relaxed text-gray-500 dark:text-gray-400 text-left md:text-center w-full max-w-2xl"
         >
             Synchronize types across all applications.
             <br />

--- a/components/midori/editor.vue
+++ b/components/midori/editor.vue
@@ -168,13 +168,13 @@ onMounted(() => {
         class="flex flex-col justify-center items-center w-full max-w-6xl mx-auto mt-6 md:my-12"
     >
         <h2
-            class="text-6xl w-full text-left sm:text-center font-bold !leading-tight text-transparent bg-clip-text bg-gradient-to-br from-blue-400 to-violet-400 mb-2"
+            class="text-6xl w-full text-left sm:text-center font-bold !leading-tight text-transparent bg-clip-text bg-gradient-to-br from-blue-500 to-violet-500 dark:from-blue-400 dark:to-violet-400 mb-2"
         >
             Try it out
         </h2>
 
         <p
-            class="text-xl md:text-2xl leading-relaxed text-gray-400 text-left md:text-center w-full max-w-2xl"
+            class="text-xl md:text-2xl leading-relaxed text-gray-500 dark:text-gray-400 text-left md:text-center w-full max-w-2xl"
         >
             Being WinterCG compliant, Elysia can run in your browser!
             <br />

--- a/components/midori/fast.vue
+++ b/components/midori/fast.vue
@@ -22,26 +22,26 @@ const graphs = [
         <section class="flex flex-col w-full max-w-lg">
             <header class="flex flex-col justify-center items-start">
                 <h2
-                    class="text-4xl leading-tight font-medium text-gray-400 mb-2"
+                    class="text-4xl leading-tight font-medium text-gray-500 dark:text-gray-400 mb-2"
                 >
                     Elysia is fast
                 </h2>
                 <h2
-                    class="text-4xl leading-tight font-medium text-gray-400 mb-4"
+                    class="text-4xl leading-tight font-medium text-gray-500 dark:text-gray-400 mb-4"
                 >
                     <span
-                        class="leading-tight text-8xl font-bold bg-clip-text text-transparent bg-gradient-to-br from-lime-300 to-cyan-300"
+                        class="leading-tight text-8xl font-bold bg-clip-text text-transparent bg-gradient-to-br from-lime-400 to-cyan-400 dark:from-lime-300 dark:to-cyan-300"
                     >
                         18x
                     </span>
                     faster than Express
                 </h2>
             </header>
-            <p class="text-xl text-gray-400 w-full max-w-lg mb-4">
+            <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4">
                 Supercharged by Bun runtime, Static Code Analysis, and various
                 micro optimization.
             </p>
-            <p class="text-xl text-gray-400 w-full max-w-lg">
+            <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg">
                 Elysia is able to outperform in various situations, being one of
                 the top-performing TypeScript frameworks.
             </p>

--- a/components/midori/hero.vue
+++ b/components/midori/hero.vue
@@ -15,7 +15,7 @@
             ElysiaJS
         </h1>
         <h2
-            class="relative text-5xl md:text-6xl md:leading-tight font-bold md:text-center leading-tight text-transparent bg-clip-text bg-gradient-to-r from-sky-300 to-indigo-400 mt-2 mb-8"
+            class="relative text-5xl md:text-6xl md:leading-tight font-bold md:text-center leading-tight text-transparent bg-clip-text bg-gradient-to-r from-sky-400 to-indigo-500  dark:from-sky-300 dark:to-indigo-400 mt-2 mb-8"
         >
             Ergonomic Framework for Humans<span
                 class="absolute w-10 md:w-12 h-10 md:h-12 bottom-0 mb-4 ml-2 md:ml-0 md:mb-10 text-indigo-400"
@@ -78,7 +78,7 @@
             </span>
         </h2>
         <h3
-            class="text-xl md:text-2xl leading-relaxed text-gray-400 text-left md:text-center w-full max-w-[49rem]"
+            class="text-xl md:text-2xl leading-relaxed text-gray-500 dark:text-gray-400 text-left md:text-center w-full max-w-[49rem]"
         >
             TypeScript framework supercharged by Bun with
             <span
@@ -101,7 +101,7 @@
                 bun create elysia app
             </code>
         </section>
-        <p class="flex justify-center items-center gap-2 text-gray-400">
+        <p class="flex justify-center items-center gap-2 text-gray-500 dark:text-gray-400">
             See why developers love Elysia
             <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/components/midori/just-return.vue
+++ b/components/midori/just-return.vue
@@ -22,18 +22,18 @@ new Elysia()
         </section>
         <header class="flex flex-col gap-3 w-full">
             <h3
-                class="text-5xl leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-green-300 to-sky-300"
+                class="text-5xl leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-green-400 to-sky-400 dark:from-green-300 dark:to-sky-300"
             >
                 Just return
             </h3>
             <p
-                class="text-xl leading-normal text-gray-400 w-full max-w-lg mb-4"
+                class="text-xl leading-normal text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4"
             >
                 No need for an additional method, just return the value to send data
                 back to the client.
             </p>
             <p
-                class="text-xl leading-normal text-gray-400 w-full max-w-lg mb-4"
+                class="text-xl leading-normal text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4"
             >
                 Whether it's a regular string, or complex JSON, just return the value
                 and Elysia will handle the rest

--- a/components/midori/openapi.vue
+++ b/components/midori/openapi.vue
@@ -23,18 +23,18 @@ new Elysia()
         </section>
         <header class="flex flex-col gap-3 w-full">
             <h3
-                class="text-5xl leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-teal-300 to-blue-300"
+                class="text-5xl leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-teal-400 to-blue-400 dark:from-teal-300 dark:to-blue-300"
             >
                 OpenAPI Compliance
             </h3>
             <p
-                class="text-xl leading-normal text-gray-400 w-full max-w-lg mb-4"
+                class="text-xl leading-normal text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4"
             >
                 Elysia generates OpenAPI 3.0 specs automatically to integrate
                 with various tools across multiple languages
             </p>
             <p
-                class="text-xl leading-normal text-gray-400 w-full max-w-lg mb-4"
+                class="text-xl leading-normal text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4"
             >
                 Thanks to OpenAPI compliance, Elysia can generate Swagger in one
                 line with the Swagger plugin.

--- a/components/midori/plugins.vue
+++ b/components/midori/plugins.vue
@@ -58,16 +58,16 @@ onMounted(() => {
         <section class="flex flex-col w-full max-w-lg">
             <header class="flex flex-col justify-center items-start">
                 <h2
-                    class="text-5xl md:text-6xl leading-tight font-bold bg-clip-text text-transparent bg-gradient-to-tr from-sky-400 to-fuchsia-400 mb-4"
+                    class="text-5xl md:text-6xl leading-tight font-bold bg-clip-text text-transparent bg-gradient-to-tr from-sky-500 to-fuchsia-500 dark:from-sky-400 dark:to-fuchsia-400 mb-4"
                 >
                     It works with that
                 </h2>
             </header>
-            <p class="text-xl text-gray-400 w-full max-w-lg mb-4">
+            <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4">
                 Being one of the most popular choices for a Bun web framework,
                 likely there is a plugin for what you want.
             </p>
-            <p class="text-xl text-gray-400 w-full max-w-lg">
+            <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg">
                 If the plugin you need is not there, it's easy to create one and share
                 it with the community.
             </p>

--- a/components/midori/quickstart.vue
+++ b/components/midori/quickstart.vue
@@ -3,12 +3,12 @@
         class="flex flex-col justify-center items-center gap-3 w-full my-24 overflow-hidden"
     >
         <h2
-            class="relative text-5xl md:text-6xl md:leading-tight font-bold text-center leading-tight text-transparent bg-clip-text bg-gradient-to-r from-sky-300 to-indigo-400"
+            class="relative text-5xl md:text-6xl md:leading-tight font-bold text-center leading-tight text-transparent bg-clip-text bg-gradient-to-r from-sky-400 to-indigo-500 dark:from-sky-300 dark:to-indigo-400"
         >
             Start in minutes
         </h2>
         <h3
-            class="text-xl md:text-2xl leading-relaxed text-gray-400 text-center w-full max-w-3xl"
+            class="text-xl md:text-2xl leading-relaxed text-gray-500 dark:text-gray-400 text-center w-full max-w-3xl"
         >
             Scaffold your project, and run server in no time
         </h3>

--- a/components/midori/simple.vue
+++ b/components/midori/simple.vue
@@ -5,12 +5,12 @@
         <section class="flex flex-col w-full">
             <header class="flex flex-col justify-center items-start">
                 <h2
-                    class="text-5xl md:text-6xl md:leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-lime-300 to-cyan-300"
+                    class="text-5xl md:text-6xl md:leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-lime-400 to-cyan-400 dark:from-lime-300 dark:to-cyan-300"
                 >
                     Made for Humans
                 </h2>
                 <h2
-                    class="text-3xl leading-tight font-medium text-gray-400 mb-8"
+                    class="text-3xl leading-tight font-medium text-gray-500 dark:text-gray-400 mb-8"
                 >
                     Focus on productivity
                     <span
@@ -20,17 +20,17 @@
                     </span>
                 </h2>
             </header>
-            <p class="text-xl text-gray-400 w-full max-w-lg mb-8">
+            <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg mb-8">
                 If you found yourself writing code for the framework, then
                 there's something wrong with the framework.
             </p>
             <div class="flex flex-col md:flex-row gap-6 md:gap-8">
-                <p class="text-xl text-gray-400 w-full max-w-lg">
+                <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg">
                     That's why Elysia invests time to experiment with design
                     decisions to craft the most ergonomic way possible for
                     everyone
                 </p>
-                <p class="text-xl text-gray-400 w-full max-w-lg">
+                <p class="text-xl text-gray-500 dark:text-gray-400 w-full max-w-lg">
                     From built-in strict-type validation to a unified type
                     system, and documentation generation, making an ideal
                     framework for building servers with TypeScript.

--- a/components/midori/type-strict.vue
+++ b/components/midori/type-strict.vue
@@ -31,18 +31,18 @@ new Elysia()
         </section>
         <header class="flex flex-col gap-3 w-full">
             <h3
-                class="text-5xl leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-teal-300 to-blue-300"
+                class="text-5xl leading-tight font-bold text-transparent bg-clip-text bg-gradient-to-br from-teal-400 to-blue-400 dark:from-teal-300 dark:to-blue-300"
             >
                 Type Strict
             </h3>
             <p
-                class="text-xl leading-normal text-gray-400 w-full max-w-lg mb-4"
+                class="text-xl leading-normal text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4"
             >
                 Powered by TypeBox, Elysia enforces type-strict validation to
                 ensure type integrity by default
             </p>
             <p
-                class="text-xl leading-normal text-gray-400 w-full max-w-lg mb-4"
+                class="text-xl leading-normal text-gray-500 dark:text-gray-400 w-full max-w-lg mb-4"
             >
                 Elysia infers types to TypeScript automatically to create
                 unified type system like statically typed language

--- a/components/tailwind.css
+++ b/components/tailwind.css
@@ -5,3 +5,11 @@
 .link {
     text-decoration: none !important;
 }
+
+::selection {
+    @apply bg-gray-900/20;
+}
+
+.dark ::selection {
+    @apply bg-gray-400/20;
+}


### PR DESCRIPTION
Improved color contrast ratio to make it easier to read in light mode, I noticed it is hard to read text only on landing page, I have also adjusted text selection color. Viewed from my sad macbook air m1 screen so that might affect things.

Comparison:

https://github.com/elysiajs/documentation/assets/138781964/17c27990-96c1-444a-b3ec-35acf2c58640

