### PR TITLE
Typos in CORS documentation

### DIFF
--- a/docs/plugins/cors.md
+++ b/docs/plugins/cors.md
@@ -75,12 +75,12 @@ Value can be one of the following:
 
 Allowed headers for an incoming request.
 
-Assign [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) header.
+Assign [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) header.
 
 Value can be one of the following:
-- **string** - Expects either a single method or a comma-delimited string
+- **string** - Expects either a single header or a comma-delimited string
     - eg: `'Content-Type, Authorization'`.
-- **string[]** - Allow multiple HTTP methods.
+- **string[]** - Allow multiple HTTP headers.
     - eg: `['Content-Type', 'Authorization']`
 
 ---
@@ -92,9 +92,9 @@ Response CORS with specified headers.
 Assign [Access-Control-Exposed-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header.
 
 Value can be one of the following:
-- **string** - Expects either a single method or a comma-delimited string.
+- **string** - Expects either a single header or a comma-delimited string.
     - eg: `'Content-Type, X-Powered-By'`.
-- **string[]** - Allow multiple HTTP methods.
+- **string[]** - Allow multiple HTTP headers.
     - eg: `['Content-Type', 'X-Powered-By']`
 
 ---

--- a/docs/plugins/cors.md
+++ b/docs/plugins/cors.md
@@ -89,7 +89,7 @@ Value can be one of the following:
 
 Response CORS with specified headers.
 
-Assign [Access-Control-Exposed-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header.
+Assign [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header.
 
 Value can be one of the following:
 - **string** - Expects either a single header or a comma-delimited string.


### PR DESCRIPTION
When reading the documentation I noticed some errors, which I'm assuming are from copy and pasting the `methods` entry 🙂. 

I changed the `methods` wording to `headers`.

I also fixed a typo, as the `exposedHeaders` field should be setting the `Access-Control-Expose-Headers` header instead of `Access-Control-Exposed-Headers`, as per the Mozilla docs. Because of this, however, I also noticed a bug in `@elysia/cors`, as it is indeed setting it as "Exposed" instead of what it should be; "Expose". Just wanted to share that, but I cannot fix that in this repo, of course.