### PR TITLE
Missing closing paren in example Response construction

### DIFF
--- a/docs/concept/handler.md
+++ b/docs/concept/handler.md
@@ -73,7 +73,7 @@ new Response(JSON.stringify({
         'Shirakami Fubuki',
         'Inugami Korone'
     ]
-}, {
+}), {
     headers: {
         'Content-Type': 'application/json'
     }


### PR DESCRIPTION
The missing closing parenthesis here makes at seem as though the Response Options should be the second argument provided to the JSON.stringify method instead of the Response constructor. Adding the closing parenthesis clarifies this point.