### PR TITLE
Fix Documentation Typos/Grammar

### DIFF
--- a/docs/blog/elysia-05.md
+++ b/docs/blog/elysia-05.md
@@ -177,7 +177,7 @@ type ContentType = |
     | 'application/x-www-form-urlencoded'
 ```
 
-You can find more detail at [explicity body](/concept/explicit-body) page in concept.
+You can find more detail at the [explicit body](/concept/explicit-body) page in concept.
 
 ### Numeric Type
 We found that one of the redundant task our developers found using Elysia is to parse numeric string.

--- a/docs/concept/explicit-body.md
+++ b/docs/concept/explicit-body.md
@@ -15,7 +15,7 @@ head:
       content: By default, Elysia will try to determine body parsing function ahead of time and pick the most suitable function to speed up the process. This allows Elysia to optimize body parser ahead of time, and reduce overhead in compile time but you can explicitly control Elysia to use a certain function.
 ---
 
-# Explicity Body
+# Explicit Body
 
 By default, Elysia will try to determine body parsing function ahead of time and pick the most suitable function to speed up the process.
 

--- a/docs/concept/life-cycle.md
+++ b/docs/concept/life-cycle.md
@@ -17,7 +17,7 @@ head:
 # Life Cycle
 Elysia supports Life Cycle events, which trigger at specific moments.
 
-A _Middleware__ or _Hook_ acts as an event listener, allowing you to "hook" into these events. This Hook capability enables you to modify data as it moves through the data pipeline.
+A _Middleware_ or _Hook_ acts as an event listener, allowing you to "hook" into these events. This Hook capability enables you to modify data as it moves through the data pipeline.
 
 Whether you aim to implement a custom body parser, generate a tailored response based on your handler, or set up an authentication guard, the Hook empowers you to harness the full potential of Elysia.
 

--- a/docs/concept/numeric.md
+++ b/docs/concept/numeric.md
@@ -35,7 +35,7 @@ app.get('/id/:id', ({ params: { id } }) => id, {
 })
 ```
 
-However, it's a little bit redundant and require a boilerplate, so Elysia has a custom type to speed up the situation with `t.Numeric`
+However, it's a little bit redundant and requires boilerplate, so Elysia has a custom type to speed up the situation with `t.Numeric`
 
 ```ts
 app.get('/id/:id', ({ params: { id } }) => id, {
@@ -45,11 +45,11 @@ app.get('/id/:id', ({ params: { id } }) => id, {
 })
 ```
 
-This allows us to convert **valid** numeric string to number automatically.
+This allows us to convert a **valid** numeric string to a number automatically.
 
-If string is not a valid numeric string, it will throw an error in the runtime and prevent and execution inside the handler.
+If the string is not a valid numeric string, it will throw an error in the runtime and prevent execution inside the handler.
 
-You can use numeric type on any property that support schema typing, including:
+You can use the numeric type on any property that supports schema typing, including:
 - params
 - query
 - headers

--- a/docs/concept/numeric.md
+++ b/docs/concept/numeric.md
@@ -17,7 +17,7 @@ head:
 
 # Numeric
 
-Sometime you might find yourself in need of numeric string like extracting path parameter, but it's typed as string and need to be convert to number.
+Sometimes you might find yourself in need of numeric string like extracting path parameter, but it's typed as string and need to be convert to number.
 
 Using Elysia's `transform` life-cycle, you can manually parse number to string and re-use the transform function in other handler as well.
 

--- a/docs/concept/plugin.md
+++ b/docs/concept/plugin.md
@@ -65,11 +65,11 @@ import { plugin } from './plugin'
 const app = new Elysia().use(plugin).listen(8080)
 ```
 
-Functional callback will allow user to access main instance values like routes, schema, store, etc.
+Functional callback will allow a user to access main instance values like routes, schema, store, etc.
 
 ## Config
 
-You can customize a plugin by creating function to return callback which accepts Elysia.
+You can customize a plugin by creating a function to return callback which accepts Elysia.
 
 ```typescript
 import { Elysia } from 'elysia'

--- a/docs/concept/plugin.md
+++ b/docs/concept/plugin.md
@@ -33,12 +33,13 @@ const app = new Elysia()
     .listen(8080)
 ```
 
-Plugin can be registered by using `use` method.
+Plugins can be registered by using `use` method.
 
-Registering a plugin will combine types between plugin and current instance, and the scope of hooks and schema get merged as well.
+Registering a plugin will combine types between the plugin and current instance, and the scope of hooks and schema get merged as well.
 
 ## Separate file
-Using plugin pattern, you can define decouple your logic into a separate file.
+
+Using the plugin pattern, you can define and decouple your logic into a separate file.
 
 ```ts
 // plugin.ts
@@ -64,11 +65,11 @@ import { plugin } from './plugin'
 const app = new Elysia().use(plugin).listen(8080)
 ```
 
-Functional callback will allow user to access main instance values like routes schema, store.
+Functional callback will allow user to access main instance values like routes, schema, store, etc.
 
 ## Config
 
-You can customize plugin by creating function to return callback which accepts Elysia.
+You can customize a plugin by creating function to return callback which accepts Elysia.
 
 ```typescript
 import { Elysia } from 'elysia'

--- a/docs/concept/route.md
+++ b/docs/concept/route.md
@@ -19,7 +19,7 @@ Like Express, and Fastify.
 
 You define route using method as a building block for your server.
 
-By calling `.[method name](path, callback, hook?)`, you attach route to Elysia, and the library will handle the routing for you.
+By calling `.[method name](path, callback, hook?)`, you attach the route to Elysia, and the library will handle the routing for you.
 
 For example:
 ```typescript
@@ -55,7 +55,7 @@ new Elysia()
 ## Path Parameters
 Path parameters can retrieve data from URL.
 
-For example, getting a user id from path like many social media is when you need a path parameters.
+For example, getting a user id from path like many social media is when you may need path parameters.
 
 ```typescript
 new Elysia()

--- a/docs/concept/route.md
+++ b/docs/concept/route.md
@@ -55,7 +55,7 @@ new Elysia()
 ## Path Parameters
 Path parameters can retrieve data from URL.
 
-For example, getting a user id from path like many social media is when you may need path parameters.
+For example, getting a user id from path (like many social media) is when you may need path parameters.
 
 ```typescript
 new Elysia()

--- a/docs/concept/state-decorate.md
+++ b/docs/concept/state-decorate.md
@@ -58,7 +58,7 @@ app
 ```
 
 ## TypeScript
-You can type state and decorator explictly using TypeScript with `as`:
+You can type state and decorator explicitly using TypeScript with `as`:
 ```typescript
 app
     // Will type version as `number | null`
@@ -68,7 +68,7 @@ app
     }) => version
 ```
 
-If explictly typed doesn't type `null` or `undefined`, make sure to set `strict` to `true` in `tsconfig.json`:
+If the explicit type doesn't type `null` or `undefined`, make sure to set `strict` to `true` in `tsconfig.json`:
 ```json
 // tsconfig.json
 {

--- a/docs/patterns/after-handle.md
+++ b/docs/patterns/after-handle.md
@@ -17,7 +17,7 @@ head:
 # After Handle
 **After Handle** can transform a response into a new response.
 
-**After Handle** is like `transform`, but instead of transforming incoming request, it is use to transform a response returned from main handler.
+**After Handle** is like `transform`, but instead of transforming the incoming request, it is used to transform a response returned from main handler.
 
 Allowing you to remap the returned value into a new value or force the value to early return.
 
@@ -42,7 +42,7 @@ new Elysia()
 The above code will return `3` as a result.
 
 ## Early return
-Sometime, you may want to prevent the on-going chain of **afterHandle**, just like **beforeHandle**, if you return the value in a **afterHandle** function, it will be an early return and skip the rest of **afterHandle**
+Sometimes you may want to prevent the on-going chain of **afterHandle**, just like **beforeHandle**. If you return the value in a **afterHandle** function, it will be an early return and skip the rest of **afterHandle**
 
 ```typescript
 import { Elysia } from 'elysia'

--- a/docs/patterns/body-parser.md
+++ b/docs/patterns/body-parser.md
@@ -15,7 +15,7 @@ head:
 ---
 
 # Body Parser
-Like Express, body-parser is a function to parse body of an incoming request.
+Like Express, body-parser is a function to parse the body of an incoming request.
 
 By default, Elysia will parse the body with content-type of:
 - `text/plain`

--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -54,7 +54,7 @@ new Elysia()
 ```
 
 ## Local Error
-You can assign error handling method to a scope using [hook](/concept/life-cycle.html#local-hook) or [guard](/concept/guard.html)
+You can assign an error handling method to a scope using [hook](/concept/life-cycle.html#local-hook) or [guard](/concept/guard.html)
 ```typescript
 app.get('/', () => 'Hello', {
     beforeHandle({ set, request: { headers } }) {
@@ -71,7 +71,7 @@ app.get('/', () => 'Hello', {
 ```
 
 ## Custom Error Message
-You can provide custom error message by providing `error`:
+You can provide a custom error message by providing `error`:
 ```ts
 new Elysia()
 	.post('/', ({ body }) => body, {
@@ -99,9 +99,9 @@ If no error response is returned, the error will be returned using `error.name`.
 :::
 
 ## Custom Error
-Elysia supports custom error both in type-level and implementaiton level.
+Elysia supports custom error both in the type-level and implementation level.
 
-Helping you to easly classify and narrow down the error type for fully type safety with an auto-complete:
+Helping you to easily classify and narrow down the error type for full type safety with auto-complete:
 ```ts
 class CustomError extends Error {
     constructor(public message: string) {

--- a/docs/patterns/trace.md
+++ b/docs/patterns/trace.md
@@ -16,18 +16,18 @@ head:
 ---
 
 # Trace
-**Trace** allow us to take tap into a life-cycle event and identifying performance bottleneck for our app.
+**Trace** allows us to tap into a life-cycle event and identify performance bottlenecks for our app.
 
 ![Example of usage of Trace](/assets/trace.webp)
 
-Performance is another one of important aspect for Elysia.
+Performance is another important aspect for Elysia.
 
-We don't want to be fast for benchmarking purpose, we want you to have a real fast server in real-world scenario.
+We don't want to be fast for benchmarking purposes, we want you to have a real fast server in real-world scenario.
 
-There are many factor that can slow down your app, and it's hard to identifying one, and **trace** can helps solve that problem
+There are many factors that can slow down your app - and it's hard to identify them, but **trace** can helps solve that problem
 
 ## Trace
-Trace can measure lifecycle execution time of each function to audit performance bottleneck of each cycle.
+Trace can measure lifecycle execution time of each function to audit the performance bottleneck of each cycle.
 
 ```ts
 import { Elysia } from 'elysia'
@@ -56,7 +56,7 @@ Please refers to [lifecycle event](/concept/life-cycle) for more information:
 ![Elysia Life Cycle](/assets/lifecycle.webp)
 
 ## Children
-You can tap deeper into each measure each function of life-cycle event by using children property of a life-cycle
+You can tap deeper and measure each function of a life-cycle event by using the **children** property of a life-cycle event
 
 ```ts
 import { Elysia } from 'elysia'
@@ -88,7 +88,7 @@ Every life cycle has support for children except for `handle`
 :::
 
 ## Name
-Measuring function by index can be hard to trace back to the function code, that's why trace provide a **name** property to easily identify the function by name.
+Measuring functions by index can be hard to trace back to the function code, that's why trace provides a **name** property to easily identify the function by name.
 
 ```ts
 import { Elysia } from 'elysia'
@@ -113,13 +113,13 @@ const app = new Elysia()
 ```
 
 ::: tip
-If you are using arrow function or unnamed function, **name** will become **"anonymous"**
+If you are using an arrow function or unnamed function, **name** will become **"anonymous"**
 :::
 
 ## Set
-Inside trace calback, you can access `Context` of the request, and can mutate the value of the request itself, for example using `set.headers` to update headers.
+Inside the trace callback, you can access `Context` of the request, and can mutate the value of the request itself, for example using `set.headers` to update headers.
 
-This is useful when you need support API like Server-Timing.
+This is useful when you need support an API like Server-Timing.
 
 ![Example of usage of Trace](/assets/server-timing.webp)
 
@@ -137,13 +137,13 @@ const app = new Elysia()
 ```
 
 ::: tip
-Using `set` inside `trace` can affect performance, as Elysia as to defer to execution to next micro-tick.
+Using `set` inside `trace` can affect performance, as Elysia defers the execution to the next micro-tick.
 :::
 
 ## Skip
-Sometime, `beforeHandle` or handler can throw can error, skipping the execution of some lifecycle.
+Sometimes, `beforeHandle` or handler can throw an error, skipping the execution of some lifecycles.
 
-By default if this happens, each life-cycle will be resolved automatically, you can track if the API is executed or not by using `skip` property
+By default if this happens, each life-cycle will be resolved automatically, and you can track if the API is executed or not by using `skip` property
 
 ```ts
 import { Elysia } from 'elysia'


### PR DESCRIPTION
Some documentation pages have incorrectly spelled words or grammatical problems, so this a general pass-over to fix some of those issues.

- Restructured some sentences for better clarity
- Added some plurals where necessary.
- Added articles (a/an/the) to improve readability.