### PR TITLE
docs(plugin): fix type error of config

### DIFF
--- a/docs/concept/plugin.md
+++ b/docs/concept/plugin.md
@@ -74,7 +74,7 @@ You can customize a plugin by creating a function to return callback which accep
 ```typescript
 import { Elysia } from 'elysia'
 
-const plugin = <const Prefix>({ prefix = '/v1' }: { prefix: Prefix }) =>
+const plugin = ({ prefix = '/v1' }: ConstructorParameters<typeof Elysia>[0] = {}) =>
     new Elysia({ prefix }).get(`/hi`, () => 'Hi')
 
 const app = new Elysia()
@@ -86,7 +86,9 @@ const app = new Elysia()
     .listen(8080)
 ```
 
-Config type will be inferred into `use`, generating auto completion and type strict as intend.
+This allows to provide part of Elysia config from `app`, and use default config if not provided.
+
+In this example, we set prefix to be `/v2`. If not provided, it defaults to `/v1`.
 
 ## Plugin deduplication
 


### PR DESCRIPTION
In the original doc, there are two problems:
* `prefix` in `<const Prefix>({ prefix = '/v1' }`
  ```
  Type 'string' is not assignable to type 'Prefix'.
     'Prefix' can be instantiated with any type independent of 'string'. ts(2322)
  ```

  <details><summary>origin in Tranditional Chinese</summary>
  ```
  類型 'string' 不可指派給類型 'Prefix'。
    'Prefix' 可以使用與 'string' 無關的任意類型來具現化。ts(2322)
  ```
  </details>

* `prefix` in `new Elysia({ prefix })`
  ```
  Type 'Prefix' is not assignable to type 'string | undefined'. ts(2322)
  ```

  <details><summary>origin in Tranditional Chinese</summary>
  ```
  類型 'Prefix' 不可指派給類型 'string | undefined'。ts(2322)
  ``
  </details>

Since I met errors, I can't be sure what the use of the original type parameter. I try to make it accept all kinds of parameters Elysia accepts.