### PR TITLE
Update top domain regexp example.

### DIFF
--- a/docs/plugins/cors.md
+++ b/docs/plugins/cors.md
@@ -140,7 +140,7 @@ import { cors } from '@elysiajs/cors'
 
 const app = new Elysia()
     .use(cors({
-        origin: /\*.saltyaom.com$/
+        origin: /.*\.saltyaom\.com$/
     }))
     .get('/', () => 'Hi')
     .listen(8080)


### PR DESCRIPTION
The original example would also match for example "*xsaltyaomycom" which is probably what is intended.