### PR TITLE
Fix incorrect code example on `Integrations / Custom 404` page

### DIFF
--- a/docs/integrations/custom-404.md
+++ b/docs/integrations/custom-404.md
@@ -20,7 +20,7 @@ You can define custom 404 using `onError` hook:
 import { Elysia } from 'elysia'
 
 new Elysia()
-    .onError((code, error) => {
+    .onError(({ code, error }) => {
         if (code === 'NOT_FOUND')
             return new Response('Not Found :(', {
                 status: 404


### PR DESCRIPTION
The code example was missing curly brackets 