### PR TITLE
Fix cookie schema example

### DIFF
--- a/docs/patterns/cookie.md
+++ b/docs/patterns/cookie.md
@@ -105,7 +105,7 @@ app.get('/', ({ cookie: { name } }) => {
     }
 }, {
     cookie: t.Cookie({
-        value: t.Object({
+        name: t.Object({
             id: t.Numeric(),
             name: t.String()
         })


### PR DESCRIPTION
In the cookie schema documentation, it is using the cookie name `name`, but the schema refers to the cookie name `value`.

<img width="719" alt="image" src="https://github.com/elysiajs/documentation/assets/13186704/62e40f1e-b749-477d-b0aa-63a21fad2793">