### PR TITLE
Fix typo

### DIFF
--- a/docs/essential/plugin.md
+++ b/docs/essential/plugin.md
@@ -108,7 +108,7 @@ Elysia can create 10k instances in a matter of milliseconds, the new Elysia inst
 
 By default, Elysia will register any plugin and handle type definitions.
 
-Some plugins may be used multiple times to provide time inference<sup>[1]</sup>, resulting in duplication of setting initial values or routes.
+Some plugins may be used multiple times to provide type inference, resulting in duplication of setting initial values or routes.
 
 Elysia avoids this by differentiating the instance by using **name** and **optional seeds** to help Elysia identify instance duplication:
 


### PR DESCRIPTION
Corrected time inference to type inference, and removed unlinked superscript. I'm guessing the superscript was meant to point to a snippet about type-dependency injection, but I'd leave it up to you to write that.