### PR TITLE
fix: example when property key is invalid

### DIFF
--- a/docs/eden/installation.md
+++ b/docs/eden/installation.md
@@ -58,7 +58,7 @@ const client = edenTreaty<App>('http://localhost:8080') // [!code ++]
 client.index.get().then(console.log)
 
 // response type: 1895
-client.id.1895.get().then(console.log)
+client.id[1895].get().then(console.log)
 
 // response type: { id: 1895, name: 'Skadi' }
 client.mirror.post({


### PR DESCRIPTION
## What

Error at the Eden Installation's example:

![Screenshot 2023-12-19 at 04 26 46](https://github.com/elysiajs/documentation/assets/6302717/21470489-5e9f-4de4-abc5-5a29bf4a4458)

## Why

More detail at [stackoverflow - In case of dot notation to access a value, the property key must be a valid identifier](https://stackoverflow.com/questions/29888256/using-integer-keys-with-dot-notation-to-access-property-in-javascript-objects).
