### PR TITLE
improve at glance port consistency

### DIFF
--- a/docs/at-glance.md
+++ b/docs/at-glance.md
@@ -57,7 +57,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
     .get('/id/:id', ({ params: { id }}) => id)
-    .listen(8080)
+    .listen(3000)
 ```
 
 The above code allow you to create a path parameter with the name of id, value that pass after `/id/` will be reflect to `params.id`.
@@ -79,7 +79,7 @@ new Elysia()
             id: t.Numeric()
         })
     })
-    .listen(8080)
+    .listen(3000)
 ```
 
 This code ensure that our path parameter **id**, will always be a numeric string and then transform to a number automatically in both runtime, and compile-time (type-level).
@@ -102,7 +102,7 @@ new Elysia()
             id: t.Numeric()
         })
     })
-    .listen(8080)
+    .listen(3000)
 ```
 
 With the Swagger plugin, you can seamlessly generate a Swagger page without additional code or specific config and share with your team effortlessly.
@@ -123,7 +123,7 @@ new Elysia()
             id: t.Numeric()
         })
     })
-    .listen(8080)
+    .listen(3000)
 
 export type App = typeof app
 ```
@@ -134,7 +134,7 @@ And on your client-side:
 import { edenTreaty } from '@elysiajs/eden'
 import type { App } from './server'
 
-const app = edenTreaty<App>('http://localhost:8080')
+const app = edenTreaty<App>('http://localhost:3000')
 
 // data is typed as number
 const { data } = await app.id['177013'].get()


### PR DESCRIPTION
IMO would be marginally easier to follow along if the port stays the same within the same at a glance page. 

Took me a few seconds to realize when following step by step that when I made the changes on my editor and I wasn't seeing what I expected was because the port the server was running on was no longer the same as in the beginning of the at a glance page.