### PR TITLE
fix: update page not found links

### DIFF
--- a/docs/blog/elysia-05.md
+++ b/docs/blog/elysia-05.md
@@ -177,7 +177,7 @@ type ContentType = |
     | 'application/x-www-form-urlencoded'
 ```
 
-You can find more detail at the [explicit body](/concept/explicit-body) page in concept.
+You can find more detail at the [explicit body](/life-cycle/parse.html#explicit-body) page in concept.
 
 ### Numeric Type
 We found that one of the redundant task our developers found using Elysia is to parse numeric string.
@@ -224,7 +224,7 @@ You can use numeric type on any property that support schema typing, including:
 
 We hope that you will find this new Numeric type useful in your server.
 
-You can find more detail at [numeric type](/concept/numeric) page in concept.
+You can find more detail at [numeric type](/validation/elysia-type.html#numeric) page in concept.
 
 With TypeBox 0.28, we are making Elysia type system we more complete, and we excited to see how it play out on your end.
 

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -188,4 +188,4 @@ When navigating to your web server, you should see the result as the following:
 | /    | POST   | Route not found :\( |
 | /hi  | GET    | Route not found :\( |
 
-You can learn more about lifecycle and error handling in [Lifecycle Event](/essential/lifecycle-event) and [error handling](/concept/error-handling)
+You can learn more about lifecycle and error handling in [Lifecycle Event](/essential/life-cycle) and [error handling](/life-cycle/on-error)

--- a/docs/life-cycle/trace.md
+++ b/docs/life-cycle/trace.md
@@ -53,7 +53,7 @@ You can trace lifecycle of the following:
 - **error** - handle error thrown during processing request
 - **response** - send a Response back to the client
 
-Please refers to [lifecycle event](/concept/life-cycle) for more information:
+Please refers to [lifecycle event](/essential/life-cycle) for more information:
 ![Elysia Life Cycle](/assets/lifecycle.webp)
 
 ## Children


### PR DESCRIPTION
# Overview

This PR is for #208.

There have some links that navigate to undefined page or page not found.
So, I have updated these links to navigate to an existing page.

# Scope of work
updated links:
`/concept/explicit-body` => `/life-cycle/parse.html#explicit-body`
`/concept/numeric` => `/validation/elysia-type.html#numeric`
`/essential/lifecycle-event` => `/essential/life-cycle`
`/concept/error-handling` => `/life-cycle/on-error`
`/concept/life-cycle` => `/essential/life-cycle`

---

If you have any feedback or suggestions, please let me know.