### PR TITLE
Update context.md

### DIFF
--- a/docs/essential/context.md
+++ b/docs/essential/context.md
@@ -101,7 +101,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
     .decorate('logger', new Logger())
-    // ✅ Because we assigned a version before, you can now access it
+    // ✅ Because we assigned an additional property called logger, you can now access it
     .get('/', ({ logger }) => {
         logger.log('hi')
 


### PR DESCRIPTION
fix typo `Because we assigned a version before, you can now access it`