### PR TITLE
🔧 fix: typo in elysia's 0.8 blog post

### DIFF
--- a/docs/blog/elysia-08.md
+++ b/docs/blog/elysia-08.md
@@ -92,7 +92,7 @@ The documentation of [Macro API](/patterns/macro) is now available in **pattern*
 The next generation of customizability is now only a reach away from your keyboard and imagination.
 
 ## New Life Cycle
-Elysia introduced a new life cycle to to fix an existing problem and highly requested API including **Resolve** and **MapResponse**:
+Elysia introduced a new life cycle to fix an existing problem and highly requested API including **Resolve** and **MapResponse**:
 resolve: a safe version of **derive**. Execute in the same queue as **beforeHandle**
 mapResponse: Execute just after **afterResponse** for providing transform function from primitive value to Web Standard Response
 


### PR DESCRIPTION
From [Discord](https://discord.com/channels/1044804142461362206/1188216452919078972/1188216452919078972)