### PR TITLE
docs: adjusts derive code snippet

### DIFF
--- a/docs/essential/context.md
+++ b/docs/essential/context.md
@@ -129,7 +129,7 @@ new Elysia()
         const auth = headers['Authorization']
 
         return {
-            bearer: auth.startsWith('Bearer ') ? auth.slice(7) : null
+            bearer: auth?.startsWith('Bearer ') ? auth.slice(7) : null
         }
     })
     .get('/', ({ bearer }) => bearer)


### PR DESCRIPTION
The previous code won't compile because auth can be undefined, and would try to fire a `startsWith` on a non-object value.