### PR TITLE
Fix couple of typos in primitive-type.md

### DIFF
--- a/docs/validation/primitive-type.md
+++ b/docs/validation/primitive-type.md
@@ -255,7 +255,7 @@ t.Array(
 <td>
 
 ```typescript
-;[1, 2, 3, 4, 5]
+[1, 2, 3, 4, 5]
 ```
 
 </td>
@@ -429,7 +429,7 @@ t.Partial(
 
 <td>
 
-```
+```typescript
 {
     y: 123
 }


### PR DESCRIPTION
1. Extra `;` char
2. Code snippet doesn't have language like the one above