### PR TITLE
fix: add public folder to file path

### DIFF
--- a/docs/essential/handler.md
+++ b/docs/essential/handler.md
@@ -158,7 +158,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
     .get('/', 'Hello Elysia')
-    .get('/video', Bun.file('kyuukurarin.mp4'))
+    .get('/video', Bun.file('public/kyuukurarin.mp4'))
     .listen(3000)
 ```
 


### PR DESCRIPTION
On the code example for Static Content handlers, there isn't an indication that the files are supposed to be on the public directory. When you try to serve a file inside the `src` dir, for instance, you will get the following error: "No such file or directory"