### PR TITLE
docs: update docs on types of query params

### DIFF
--- a/docs/validation/schema-type.md
+++ b/docs/validation/schema-type.md
@@ -122,7 +122,7 @@ Most browsers disable the attachment of the body by default for **GET** and **HE
 
 ## Query
 
-Query string or search parameter is an addition string provided after pathname starting with **?** to provide additional information, usually for customized web server behavior like filter or search.
+A query string is a part of the URL that starts with **?** and can contain one or more query parameters, which are key-value pairs used to convey additional information to the server, usually for customized behavior like filter or search.
 
 ![URL Object](/essential/url-object.svg)
 
@@ -132,7 +132,7 @@ Query is provided after the **?** in Fetch API.
 fetch('https://elysiajs.com/?name=Elysia')
 ```
 
-This field is usually used to enforce an important query name or a specific value pattern.
+When specifying query parameters, it's crucial to understand that all query parameter values must be represented as strings. This is due to how they are encoded and appended to the URL.
 
 ### Example
 


### PR DESCRIPTION
This pull request includes updates to our documentation on query parameters. The changes are twofold:

1. **Clarification on Query Parameters and Strings**: Improved the distinction between query strings and parameters to enhance readability and precision.

2. **String Type Requirement for Query Parameters**: Added a note specifying that all query parameters must be strings due to URL encoding constraints. This clarification addresses potential confusion, as both the Eden Treaty and validation libraries suggest broader type support. However, the technical requirement for string types is evident upon reviewing the implementation in [fetch/index.ts](https://github.com/elysiajs/eden/blob/main/src/fetch/index.ts) and [treaty/utils.ts](https://github.com/elysiajs/eden/blob/main/src/treaty/utils.ts).

These modifications aim to correct ambiguities in our documentation, particularly around the types of values that can be passed as query parameters. The update is based on practical findings and is intended to prevent misunderstandings and bugs in API usage.