### PR TITLE
fix: removed redundant backticks from the end of the `index.md` page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -113,4 +113,3 @@ await eden.user.age.patch({
 
 
 </Landing>
-```


### PR DESCRIPTION
This fixes these backticks that render at the bottom of https://elysiajs.com/:

<img width="1327" alt="Zrzut ekranu 2024-03-12 o 16 34 22" src="https://github.com/elysiajs/documentation/assets/565022/bd0659e2-bc11-44f0-a1f7-c84b040b7526">
