### PR TITLE
Improve examples in Essential Route docs

### DIFF
--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -19,8 +19,8 @@ import Playground from '../../components/nearl/playground.vue'
 import { Elysia } from 'elysia'
 
 const demo1 = new Elysia()
-    .get('/', () => 'hello')
-    .post('/hello', () => 'hi')
+    .get('/', () => 'Landing')
+    .get('/hello', () => 'Hi')
 
 const demo2 = new Elysia()
     .get('/', () => 'hello')

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -32,9 +32,7 @@ const demo3 = new Elysia()
     .route('M-SEARCH', '/m-search', () => 'connect')
 
 const demo4 = new Elysia()
-    .get('/', () => 'hello')
-    .post('/', () => 'hello')
-    .delete('/', () => 'hello')
+    .all('/', () => 'hi')
 
 const demo5 = new Elysia()
     .get('/', () => 'hi')

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -20,7 +20,7 @@ import { Elysia } from 'elysia'
 
 const demo1 = new Elysia()
     .get('/', () => 'hello')
-    .post('/hi', () => 'hi')
+    .post('/hello', () => 'hi')
 
 const demo2 = new Elysia()
     .get('/', () => 'hello')

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -96,7 +96,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
     .get('/', () => 'hello')
-    .post('/hi', () => 'hi')
+    .post('/hi', () => 'world')
     .listen(3000)
 ```
 

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -29,7 +29,7 @@ const demo2 = new Elysia()
 const demo3 = new Elysia()
     .get('/get', () => 'hello')
     .post('/post', () => 'hi')
-    .route('M-SEARCH', '/m-search', () => 'connect') 
+    .route('M-SEARCH', '/m-search', () => 'connect')
 
 const demo4 = new Elysia()
     .get('/', () => 'hello')

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -37,9 +37,9 @@ const demo4 = new Elysia()
     .delete('/', () => 'hello')
 
 const demo5 = new Elysia()
-    .get('/', () => 'hello')
-    .post('/', () => 'hello')
-    .get('/hi', ({ error }) => error(404))
+    .get('/', () => 'hi')
+    .post('/', ({ error }) => error(404, 'Route not found :('))
+    .get('/hi', ({ error }) => error(404, 'Route not found :('))
 </script>
 
 # Route


### PR DESCRIPTION
I tried to fix all concerns raised in #308 

The playground now returns the values specified in the code examples.