### PR TITLE
fix: essential/scope response example

### DIFF
--- a/docs/essential/scope.md
+++ b/docs/essential/scope.md
@@ -33,6 +33,15 @@ const demo2 = new Elysia()
     .use(plugin2)
     .get('/parent', () => 'parent')
 
+const mock2 = {
+    '/child': {
+        'GET': 'hi'
+    },
+    '/parent': {
+        'GET': 'hi'
+    }
+}
+
 const plugin3 = new Elysia()
     .onBeforeHandle({ as: 'global' }, () => {
         return 'overwrite'
@@ -44,6 +53,15 @@ const demo3 = new Elysia()
         .get('/inner', () => 'inner')
     )
     .get('/outer', () => 'outer')
+
+const mock3 = {
+    '/inner': {
+        'GET': 'overwrite'
+    },
+    '/outer': {
+        'GET': 'outer'
+    }
+}
 </script>
 
 By default, hook and schema is scope to current instance only not global.
@@ -203,7 +221,7 @@ const app = new Elysia()
     .listen(3000)
 ```
 
-<Playground :elysia="demo3" />
+<Playground :elysia="demo3" :mock="mock3" />
 
 Evaluating the route, should logs as follows:
 | route       | response  |
@@ -309,4 +327,4 @@ const main = new Elysia()
     .get('/parent', () => 'parent')
 ```
 
-<Playground :elysia="demo2" />
+<Playground :elysia="demo2" :mock="mock2" />


### PR DESCRIPTION
I tried to check this response example on local but it works well.
then I deployed on website `onBeforeHandle ` didn't works  and I don't know why.

I decide to mock response example and pass to props instead.

GET `/inner ` response got
<img width="775" alt="image" src="https://github.com/elysiajs/documentation/assets/79430027/f5c06ffb-c504-46ac-b65a-dc71ac5322d4">
but actually response should be
<img width="386" alt="image" src="https://github.com/elysiajs/documentation/assets/79430027/029beb70-36e3-435d-afed-f97804ef17f0">

`/child` & `/parent` should be overwrite w/ `'hi'`
<img width="727" alt="image" src="https://github.com/elysiajs/documentation/assets/79430027/1255a1f6-413d-474c-b705-f266f35007c6">
