### PR TITLE
Fixed: change words in docs/essential/route.md

### DIFF
--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -52,8 +52,8 @@ We can define a route by calling a **method named after HTTP verbs**, passing a 
 import { Elysia } from 'elysia'
 
 new Elysia()
-    .get('/', () => 'Landing')
-    .get('/hello', () => 'Hi')
+    .get('/', () => 'hello')
+    .get('/hello', () => 'hi')
     .listen(3000)
 ```
 

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -53,7 +53,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
     .get('/', () => 'hello')
-    .get('/hello', () => 'hi')
+    .get('/hi', () => 'hi')
     .listen(3000)
 ```
 


### PR DESCRIPTION
I changed the code snippet of demo1 to use the same words with the interactive window of demo1 for consistency.
