### PR TITLE
Submit Compression Plugin

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -90,7 +90,7 @@ This is to ensure developers end up with a performant web server they intend to 
 -   [Elysia Auth Drizzle](https://github.com/qlaffont/elysia-auth-drizzle) - Library who handle authentification with JWT (Header/Cookie/QueryParam).
 -   [graceful-server-elysia](https://github.com/qlaffont/graceful-server-elysia) - Library inspired by [graceful-server](https://github.com/gquittet/graceful-server).
 -   [Logixlysia](https://github.com/PunGrumpy/logixlysia) - A beautiful and simple logging middleware for ElysiaJS with colors and timestamps.
-
+-   [Elysia Compress](https://github.com/vermaysha/elysia-compress) - ElysiaJS plugin to compress responses inspired by [@fastify/compress](https://github.com/fastify/fastify-compress)
 ---
 
 If you have a plugin written for Elysia, feel free to add your plugin to the list by **clicking <i>Edit this page on GitHub</i>** below 👇


### PR DESCRIPTION
This plugin is used to compress all responses that will be sent to the client, especially responses in the form of text (json/string).

Supports brotli, gzip, and deflate compression and can be set which compression algorithm will be used, such as ordering it to only support gzip and deflate compression.

Automatically detects which encodings are supported by the client using the `accept-encoding` header.