### PR TITLE
Docs changes for onParse

### DIFF
--- a/docs/life-cycle/parse.md
+++ b/docs/life-cycle/parse.md
@@ -34,7 +34,7 @@ Below is an example code to retrieve value based on custom headers.
 import { Elysia } from 'elysia'
 
 new Elysia()
-    .onParse(({ request, contentType }) => {
+    .onParse(({ request }, contentType) => {
         if (contentType === 'application/custom-type')
             return request.text()
     })


### PR DESCRIPTION
At the moment docs state that you should get contentType from ctx, while it's passed as a 2nd argument instead