### PR TITLE
fix: bearer had multiple entries in plugins

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -361,10 +361,6 @@ export default defineConfig({
                         link: '/plugins/bearer'
                     },
                     {
-                        text: 'Bearer',
-                        link: '/plugins/bearer'
-                    },
-                    {
                         text: 'CORS',
                         link: '/plugins/cors'
                     },


### PR DESCRIPTION
### Description
Fixed an issue where the "Bearer" had multiple entries in the plugins section of the sidebar. 