### PR TITLE
Add prismabox to the docs

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -101,6 +101,9 @@ This is to ensure developers end up with a performant web server they intend to 
 -   [Elysia Accepts](https://github.com/morigs/elysia-accepts) - Elysia plugin for accept headers parsing and content negotiation
 -   [Elysia Compression](https://github.com/chneau/elysia-compression) - Elysia plugin for compressing responses
 -   [Elysia Logger](https://github.com/chneau/elysia-logger) - Elysia plugin for logging HTTP requests and responses inspired by [hono/logger](https://hono.dev/docs/middleware/builtin/logger)
+
+## Complementaray projects:
+-   [prismabox](https://github.com/m1212e/prismabox) - Generator for typebox schemes based on your database models, works well with elysia
 ---
 
 If you have a plugin written for Elysia, feel free to add your plugin to the list by **clicking <i>Edit this page on GitHub</i>** below 👇


### PR DESCRIPTION
I've been asked to add prismabox to the plugin list in the elysia docs: https://github.com/m1212e/prismabox/discussions/17

Since it's not a "real" plugin in the elysia way, I opened a new list for projects that go well with elysia but are not plugins as per elysias definition.