### PR TITLE
Update query example schema-type.md

### DIFF
--- a/docs/validation/schema-type.md
+++ b/docs/validation/schema-type.md
@@ -172,10 +172,10 @@ The validation should be as follows:
 | Query | Validation |
 | ---- | --------- |
 | /?name=Elysia | ✅ |
-| /?name=1 | ❌ |
+| /?name=1 | ✅ |
 | /?alias=Elysia | ❌ |
 | /?name=ElysiaJS&alias=Elysia | ✅ |
-| `undefined` | ❌ |
+| / | ❌ |
 
 ## Params
 

--- a/docs/validation/schema-type.md
+++ b/docs/validation/schema-type.md
@@ -169,11 +169,12 @@ new Elysia()
 ```
 
 The validation should be as follows:
-| Body | Validation |
-| --- | --------- |
-| \{ name: 'Elysia' \} | ✅ |
-| \{ name: 1 \} | ❌ |
-| \{ alias: 'Elysia' \} | ❌ |
+| Query | Validation |
+| ---- | --------- |
+| /?name=Elysia | ✅ |
+| /?name=1 | ❌ |
+| /?alias=Elysia | ❌ |
+| /?name=ElysiaJS&alias=Elysia | ✅ |
 | `undefined` | ❌ |
 
 ## Params


### PR DESCRIPTION
The example for the query schema type is printed as an object, shouldn't it be shown as a url like the very fist example of the page ?
Like the URL column of this picture: 
![image](https://github.com/user-attachments/assets/be1bf3ff-95c6-4773-8124-f498580af9af)


Also added a valid example of using mandatory name along with optional alias. 
