### PR TITLE
Update Playground component to use demo2 instead of demo3 in plugin.md

### DIFF
--- a/docs/essential/plugin.md
+++ b/docs/essential/plugin.md
@@ -171,7 +171,7 @@ const app = new Elysia()
     .listen(3000)
 ```
 
-<Playground :elysia="demo3" />
+<Playground :elysia="demo2" />
 
 Once passed to `Elysia.use`, functional callback behaves as a normal plugin except the property is assigned directly to
 


### PR DESCRIPTION
Modify the Playground component to use 'demo2' instead of 'demo3' in the 'plugin.md' file, particularly in the 'Functional Callback' section, to ensure the fetch API playground retrieves the correct path.

<img width="718" alt="image" src="https://github.com/user-attachments/assets/d3dabf07-05a4-4fb2-965d-e2f15426fd7f">