### PR TITLE
fix(treaty): send a message once the connection is opened

### DIFF
--- a/docs/eden/treaty/websocket.md
+++ b/docs/eden/treaty/websocket.md
@@ -18,28 +18,30 @@ head:
 Eden Treaty supports WebSocket using `subscribe` method.
 
 ```typescript twoslash
-import { Elysia, t } from 'elysia'
-import { treaty } from '@elysiajs/eden'
+import { Elysia, t } from "elysia";
+import { treaty } from "@elysiajs/eden";
 
 const app = new Elysia()
-    .ws('/chat', {
-        body: t.String(),
-        response: t.String(),
-        message(ws, message) {
-            ws.send(message)
-        }
-    })
-    .listen(3000)
+  .ws("/chat", {
+    body: t.String(),
+    response: t.String(),
+    message(ws, message) {
+      ws.send(message);
+    },
+  })
+  .listen(3000);
 
-const api = treaty<typeof app>('localhost:3000')
+const api = treaty<typeof app>("localhost:3000");
 
-const chat = api.chat.subscribe()
+const chat = api.chat.subscribe();
 
 chat.subscribe((message) => {
-    console.log('got', message)
-})
+  console.log("got", message);
+});
 
-chat.send('hello from client')
+chat.on("open", () => {
+  chat.send("hello from client");
+});
 ```
 
 **.subscribe** accepts the same parameter as `get` and `head`.


### PR DESCRIPTION
I've just been reading through the documentation. I found that Treaty's WebSocket example produces an error that the connection is not in the right state. My friend @dreamqip found that the problem was that `send` was running before the connection had been. That's what I'm suggesting to change. Hope it helps!