### PR TITLE
docs: Warn users about export Elysia as a default

### DIFF
--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -49,11 +49,15 @@ We can define a route by calling a **method named after HTTP verbs**, passing a 
 ```typescript twoslash
 import { Elysia } from 'elysia'
 
-new Elysia()
+export const app = new Elysia()
     .get('/', () => 'hello')
     .get('/hi', () => 'hi')
     .listen(3000)
 ```
+
+::: warning
+Do **not** `export default app` as Bun's [auto-execution](https://bun.sh/docs/api/http#object-syntax) feature will cause the Elysia server to run twice.
+:::
 
 We can access the web server by going to **http://localhost:3000**
 


### PR DESCRIPTION
I hope you'll consider making this small documentation change. It was something I ran into when first learning Elysia and ended up wasting several minutes of troubleshooting on this.

If there's a better place to put this warning, let me know.

See elysiajs/elysia#550 for context.