### PR TITLE
fix: drizzle integration example

### DIFF
--- a/docs/integrations/drizzle.md
+++ b/docs/integrations/drizzle.md
@@ -37,14 +37,14 @@ const user = sqliteTable('user', {
     password: text('password').notNull(),
 })
 
-const createUser = createInsertSchema(user)
+const insertUserSchema = createInsertSchema(user)
 
 const auth = new Elysia({ prefix: '/auth' })
     .put(
         '/sign-up',
-        ({ body }) => createUser(body),
+        ({ body }) => body,
         {
-            body: t.Omit(createUser, ['id'])
+            body: t.Omit(insertUserSchema, ['id'])
         }
     )
 ```
@@ -64,7 +64,7 @@ const user = sqliteTable('user', {
     image: text('image')
 })
 
-const createUser = createInsertSchema(user, {
+const insertUserSchema = createInsertSchema(user, {
     image: t.File({ // [!code ++]
         type: 'image', // [!code ++]
         maxSize: '2m' // [!code ++]
@@ -77,10 +77,10 @@ const auth = new Elysia({ prefix: '/auth' })
         async ({ body: { image, ...body } }) => {
             const imageURL = await uploadImage(image) // [!code ++]
 // [!code ++]
-            return createUser({ image: imageURL, ...body }) // [!code ++]
+            return { image: imageURL, ...body } // [!code ++]
         },
         {
-            body: t.Omit(createUser, ['id'])
+            body: t.Omit(insertUserSchema, ['id'])
         }
     )
 ```


### PR DESCRIPTION
Changes:
- Reason for rename: better to match styling with "https://orm.drizzle.team/docs/typebox" guide.
- Return the body as response directly because `createUser` is previous example was not a callable.

PS:
- $defaultFn is drizzle is a runtime function hence will only be triggered when `user` is inserted via drizzle-orm client. So returned body will not have `id` field.