### PR TITLE
📘: add some parameters to `build` script at `quick-start` page 

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -58,7 +58,7 @@ Open your `package.json` file and add the following scripts:
 {
   "scripts": {
     "dev": "bun --watch src/index.ts",
-    "build": "bun build src/index.ts",
+    "build": "bun build src/index.ts --target bun --outdir ./build",
     "start": "NODE_ENV=production bun src/index.ts",
     "test": "bun test"
   }

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -58,7 +58,7 @@ Open your `package.json` file and add the following scripts:
 {
   "scripts": {
     "dev": "bun --watch src/index.ts",
-    "build": "bun build src/index.ts --target bun --outdir ./build",
+    "build": "bun build src/index.ts --target bun --outdir ./dist",
     "start": "NODE_ENV=production bun src/index.ts",
     "test": "bun test"
   }


### PR DESCRIPTION
I think it's worth adding some parameters because for now this command is show the result inthe console.

add `--outdir` to specify directory where bundled file will be created and also `--target bun` because it is the best practice to run in Bun (but I know that Elysia WinterCG is compatible and the user may want to build a serverless environment)

> For generating bundles that are intended to be run by the Bun runtime. In many cases, it isn't necessary to bundle server-side code; you can directly execute the source code without modification. However, bundling your server code can reduce startup times and improve running performance.
> 
> All bundles generated with target: "bun" are marked with a special // @bun pragma, which indicates to the Bun runtime that there's no need to re-transpile the file before execution.
> 
> If any entrypoints contains a Bun shebang (#!/usr/bin/env bun) the bundler will default to target: "bun" instead of "browser".


Related - https://github.com/elysiajs/elysia/issues/420