### PR TITLE
📘Docs:  [Bug] Link leads to 404 Page

### DIFF
--- a/docs/integrations/cheat-sheet.md
+++ b/docs/integrations/cheat-sheet.md
@@ -266,7 +266,7 @@ new Elysia()
 ## OpenAPI documentation
 Create interactive documentation using Scalar (or optionally Swagger)
 
-See [Documentation](/patterns/documentation)
+See [Documentation](/patterns/openapi)
 
 ```typescript
 import { Elysia } from 'elysia'


### PR DESCRIPTION
Location: Cheat Sheet page under the OpenAPI Documentation

Link leads to patterns/documentation instead of patterns/openapi
