### PR TITLE
📘Doc: [Bug] Link leads to 404 in Cheat Sheet

### DIFF
--- a/docs/integrations/cheat-sheet.md
+++ b/docs/integrations/cheat-sheet.md
@@ -177,7 +177,7 @@ new Elysia()
 ## Guard
 Enforce a data type of sub routes
 
-See [Scope](/essential/scope.html#guard)
+See [Scope](/essential/validation.html#guard)
 
 ```typescript twoslash
 // @errors: 2345


### PR DESCRIPTION
Bug: Link to Guard Scope Leads to 404

Changed link to validation.html#guard