### PR TITLE
add tip for ensuring that bun types are installed when using bun

### DIFF
--- a/docs/eden/installation.md
+++ b/docs/eden/installation.md
@@ -146,3 +146,6 @@ app.listen(3000)
 ```
 
 We recommend to **always use method chaining** to provide an accurate type inference.
+
+### Bun
+If using bun, ensure that you have installed `@types/bun`.


### PR DESCRIPTION
I've seen multiple people run into this issue on Discord.
It's easy to miss, perhaps we should add `@types/bun` when using `bun create elysia app` as well?