### PR TITLE
fix: typo in 418 error message

### DIFF
--- a/docs/integrations/cheat-sheet.md
+++ b/docs/integrations/cheat-sheet.md
@@ -105,7 +105,7 @@ new Elysia()
     .get('/', ({ set, error }) => {
         set.headers['x-powered-by'] = 'Elysia'
 
-        return error(418, "I'm teapod")
+        return error(418, "I'm a teapot")
     })
     .listen(3000)
 ```


### PR DESCRIPTION
This PR adjusts the `418` error message to match the correct message and other examples in the Elysia code.