### PR TITLE
📘doc: fix typo

### DIFF
--- a/docs/essential/handler.md
+++ b/docs/essential/handler.md
@@ -377,7 +377,7 @@ new Elysia()
 
 ## Handle
 
-As Elysia is built on top of Web Syandard Request, we can programmatically test it using `Elysia.handle`.
+As Elysia is built on top of Web Standard Request, we can programmatically test it using `Elysia.handle`.
 
 ```typescript
 import { Elysia } from 'elysia'


### PR DESCRIPTION
"Syandard" => "Standard"