### PR TITLE
fix the broken link in the group section.

### DIFF
--- a/docs/integrations/cheat-sheet.md
+++ b/docs/integrations/cheat-sheet.md
@@ -113,7 +113,7 @@ new Elysia()
 ## Group
 Define a prefix once for sub routes
 
-See [Group](/patterns/group.html)
+See [Group](/essential/route.html#group)
 
 ```typescript
 import { Elysia } from 'elysia'


### PR DESCRIPTION
The current link is broken.

![Shot 2024-10-14 at 09 10 16@2x](https://github.com/user-attachments/assets/4b7340ca-c0ac-4b05-bdd8-dc0f1a05c34f)
