### PR TITLE
📘 doc: fix grammar on homepage and at-a-glance

### DIFF
--- a/components/fern/benchmark.vue
+++ b/components/fern/benchmark.vue
@@ -53,7 +53,7 @@
                 </li>
             </ol>
             <p class="text-sm mt-3 text-gray-400">
-                Measure in requests/second. Result from
+                Measured in requests/second. Result from
                 <a
                     href="https://www.techempower.com/benchmarks/#hw=ph&test=plaintext&section=data-r22"
                     target="_blank"

--- a/components/fern/beyond.vue
+++ b/components/fern/beyond.vue
@@ -139,7 +139,7 @@
                 </h2>
                 <p>
                     Like tRPC, Elysia provides type-safety from the backend to
-                    the frontend without code generation. Interaction between
+                    the frontend without code generation. The interaction between
                     frontend and backend is type-checked at compile time.
                 </p>
             </header>

--- a/components/fern/easy.vue
+++ b/components/fern/easy.vue
@@ -7,7 +7,7 @@
                     <h2
                         class="text-6xl font-semibold text-gradient from-sky-500 to-violet-500 leading-[4.25rem]"
                     >
-                        Design for Human
+                        Design for Humans
                     </h2>
                 </div>
                 <p class="max-w-md leading-normal">
@@ -54,10 +54,10 @@
                         ></polyline>
                         <line x1="12" y1="22.08" x2="12" y2="12"></line>
                     </svg>
-                    Just Return
+                    Just return
                 </h4>
-                <p>A string, number or complex JSON</p>
-                <p>All we need to do is just return</p>
+                <p>A string, number, or complex JSON</p>
+                <p>All we need to do is return</p>
             </article>
             <article>
                 <h4>
@@ -84,10 +84,10 @@
                         <circle cx="8.5" cy="8.5" r="1.5"></circle>
                         <polyline points="21 15 16 10 5 21"></polyline>
                     </svg>
-                    File built-in
+                    File support built-in
                 </h4>
                 <p>To send a file or image, just return</p>
-                <p>Nothing more or nothing less</p>
+                <p>Nothing more or less</p>
             </article>
             <article>
                 <h4>
@@ -120,9 +120,8 @@
                     <span class="font-mono text-violet-500 font-bold"
                         >yield</span
                     >
-                    to stream response
+                    to stream a response
                 </p>
-                <p>All we need to do is just return</p>
             </article>
             <article>
                 <h4>
@@ -142,7 +141,7 @@
                             points="22 12 18 12 15 21 9 3 6 12 2 12"
                         ></polyline>
                     </svg>
-                    Data in realtime
+                    Data in real-time
                 </h4>
                 <p>With µWebSocket built-in</p>
                 <p>Send live data in just 3 lines</p>

--- a/components/fern/easy.vue
+++ b/components/fern/easy.vue
@@ -122,6 +122,7 @@
                     >
                     to stream a response
                 </p>
+                <p>All we need to do is return</p>
             </article>
             <article>
                 <h4>

--- a/components/fern/features.vue
+++ b/components/fern/features.vue
@@ -1,20 +1,32 @@
 <template>
     <article id="features" class="fern-gap">
-        <div class="mb-6 flex w-full flex-col items-start gap-4 sm:mb-12 md:flex-row md:items-end md:justify-between">
+        <div
+            class="flex flex-col md:flex-row md:justify-between items-start md:items-end gap-4 w-full mb-6 sm:mb-12"
+        >
             <h2
-                class="text-left text-5xl font-medium leading-[3.5rem] text-gray-700 dark:text-gray-300 sm:text-6xl sm:leading-[4.5rem]"
+                class="text-5xl sm:text-6xl text-left text-gray-700 dark:text-gray-300 font-medium leading-[3.5rem] sm:leading-[4.5rem]"
             >
-                <span class="text-xl font-medium text-gray-500 dark:text-gray-400">To summarize</span><br />
+                <span
+                    class="text-gray-500 dark:text-gray-400 font-medium text-xl"
+                    >To summarize</span
+                ><br />
                 Only the
-                <span class="text-gradient from-purple-500 to-sky-400 font-semibold">best</span>
+                <span
+                    class="text-gradient font-semibold from-purple-500 to-sky-400"
+                    >best</span
+                >
                 <br />
                 for the bold
             </h2>
-            <p class="w-full dark:font-medium dark:text-gray-400 sm:w-1/2 lg:w-full lg:max-w-lg lg:pr-24">
-                <span class="mb-2 inline-block">For builders, inventors, and visionaries</span>
+            <p
+                class="w-full sm:w-1/2 lg:max-w-lg lg:w-full lg:pr-24 dark:text-gray-400 dark:font-medium"
+            >
+                <span class="inline-block mb-2"
+                    >For builders, inventors, and visionaries</span
+                >
                 <br />
-                We spent years studying the strengths and weaknesses of JavaScript frameworks, all to deliver an
-                exceptional experience
+                We spent years studying the strengths and weaknesses of
+                JavaScript frameworks, all to deliver an exceptional experience
             </p>
         </div>
         <div class="list">
@@ -28,29 +40,36 @@
                 <h3>Maximum Type Safety</h3>
                 <h4 class="text-blue-400">Dynamic type safety</h4>
                 <p>Built from type to runtime</p>
-                <p>Elysia learns from your codebase, adapts, and enforces your types</p>
+                <p>
+                    Elysia learn from your codebase, adapt, enforce with your
+                    type
+                </p>
             </section>
             <section>
                 <h3>Productive in a reach</h3>
                 <h4 class="text-teal-400">The best experience of today</h4>
-                <p>Ergonomically designed for humans, prioritizing DX. No technical non-sense</p>
+                <p>
+                    Ergonomically designed for human, putting DX at the
+                    priority. No technical non-sense
+                </p>
             </section>
         </div>
-        <h5 class="mt-6 text-right text-base text-gray-400/75">
-            These are the pillars we built Elysia upon,<br />to deliver the best experience yet
+        <h5 class="text-right text-base mt-6 text-gray-400/75">
+            These are the pillars we built Elysia upon,<br />to deliver the best
+            experience yet
         </h5>
     </article>
 </template>
 
 <style>
 #features {
-    @apply relative mx-auto mb-12 mt-4 w-full max-w-5xl;
+    @apply relative max-w-5xl w-full mx-auto mt-4 mb-12;
 
     & > .list {
-        @apply z-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3;
+        @apply grid sm:grid-cols-2 lg:grid-cols-3 gap-4 z-10;
 
         & > section {
-            @apply relative flex w-full transform flex-col rounded-3xl border border-b-purple-100 border-l-blue-200 border-r-blue-100 border-t-purple-200 p-6 transition-all duration-200 ease-out hover:-translate-y-2 dark:border-b-purple-300/40 dark:border-l-blue-400/40 dark:border-r-blue-300/40 dark:border-t-purple-400/50 dark:text-gray-400;
+            @apply relative flex flex-col w-full rounded-3xl p-6 border border-r-blue-100 border-b-purple-100 border-t-purple-200 border-l-blue-200 dark:border-r-blue-300/40 dark:border-b-purple-300/40 dark:border-t-purple-400/50 dark:border-l-blue-400/40 transform hover:-translate-y-2 transition-all ease-out duration-200 dark:text-gray-400;
             box-shadow: 0 7px 40px rgba(48, 160, 255, 0.075);
 
             &:hover {
@@ -70,20 +89,56 @@
             }
 
             & > h4 {
-                @apply mb-3 mt-0.5 inline-block text-base font-medium dark:text-gray-400/90;
+                @apply inline-block text-base font-medium mt-0.5 mb-3 dark:text-gray-400/90;
             }
 
             &:nth-child(1) {
                 @apply bg-white dark:bg-gray-900;
-                background-image: radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 70%, transparent 150%),
-                    radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 90%, transparent 150%),
-                    radial-gradient(at 9% 67%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
-                    radial-gradient(at 22% 0%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
-                    radial-gradient(at 97% 49%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
-                    radial-gradient(at 100% 75%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
-                    radial-gradient(at 75% 100%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
-                    radial-gradient(at 40% 100%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
-                    radial-gradient(at 72% 0%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
+                background-image: radial-gradient(
+                        closest-side at center,
+                        rgba(255, 255, 255, 1) 70%,
+                        transparent 150%
+                    ),
+                    radial-gradient(
+                        closest-side at center,
+                        rgba(255, 255, 255, 1) 90%,
+                        transparent 150%
+                    ),
+                    radial-gradient(
+                        at 9% 67%,
+                        hsla(223, 100%, 65%, 0.14) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 22% 0%,
+                        hsla(210, 100%, 69%, 0.29) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 97% 49%,
+                        hsla(240, 100%, 87%, 0.35) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 100% 75%,
+                        hsla(280, 100%, 75%, 0.26) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 75% 100%,
+                        hsla(22, 100%, 77%, 0.19) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 40% 100%,
+                        hsla(240, 100%, 70%, 0.15) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 72% 0%,
+                        hsla(343, 100%, 76%, 0.17) 0px,
+                        transparent 50%
+                    );
 
                 html.dark & {
                     background-image: radial-gradient(
@@ -91,27 +146,91 @@
                             theme(colors.gray.800) 70%,
                             transparent 150%
                         ),
-                        radial-gradient(at 9% 67%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
-                        radial-gradient(at 22% 0%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
-                        radial-gradient(at 97% 49%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
-                        radial-gradient(at 100% 75%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
-                        radial-gradient(at 75% 100%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
-                        radial-gradient(at 40% 100%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
-                        radial-gradient(at 72% 0%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
+                        radial-gradient(
+                            at 9% 67%,
+                            hsla(223, 100%, 65%, 0.14) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 22% 0%,
+                            hsla(210, 100%, 69%, 0.29) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 97% 49%,
+                            hsla(240, 100%, 87%, 0.35) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 100% 75%,
+                            hsla(280, 100%, 75%, 0.26) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 75% 100%,
+                            hsla(22, 100%, 77%, 0.19) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 40% 100%,
+                            hsla(240, 100%, 70%, 0.15) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 72% 0%,
+                            hsla(343, 100%, 76%, 0.17) 0px,
+                            transparent 50%
+                        );
                 }
             }
 
             &:nth-child(2) {
                 @apply bg-white dark:bg-gray-900;
-                background-image: radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 70%, transparent 150%),
-                    radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 90%, transparent 150%),
-                    radial-gradient(at 7% 95%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
-                    radial-gradient(at 89% 10%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
-                    radial-gradient(at 30% 0%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
-                    radial-gradient(at 100% 54%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
-                    radial-gradient(at 61% 0%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
-                    radial-gradient(at 2% 48%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
-                    radial-gradient(at 80% 100%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
+                background-image: radial-gradient(
+                        closest-side at center,
+                        rgba(255, 255, 255, 1) 70%,
+                        transparent 150%
+                    ),
+                    radial-gradient(
+                        closest-side at center,
+                        rgba(255, 255, 255, 1) 90%,
+                        transparent 150%
+                    ),
+                    radial-gradient(
+                        at 7% 95%,
+                        hsla(223, 100%, 65%, 0.14) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 89% 10%,
+                        hsla(210, 100%, 69%, 0.29) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 30% 0%,
+                        hsla(240, 100%, 87%, 0.35) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 100% 54%,
+                        hsla(280, 100%, 75%, 0.26) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 61% 0%,
+                        hsla(22, 100%, 77%, 0.19) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 2% 48%,
+                        hsla(240, 100%, 70%, 0.15) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 80% 100%,
+                        hsla(343, 100%, 76%, 0.17) 0px,
+                        transparent 50%
+                    );
 
                 html.dark & {
                     background-image: radial-gradient(
@@ -119,13 +238,41 @@
                             theme(colors.gray.800) 70%,
                             transparent 150%
                         ),
-                        radial-gradient(at 7% 95%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
-                        radial-gradient(at 89% 10%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
-                        radial-gradient(at 30% 0%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
-                        radial-gradient(at 100% 54%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
-                        radial-gradient(at 61% 0%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
-                        radial-gradient(at 2% 48%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
-                        radial-gradient(at 80% 100%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
+                        radial-gradient(
+                            at 7% 95%,
+                            hsla(223, 100%, 65%, 0.14) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 89% 10%,
+                            hsla(210, 100%, 69%, 0.29) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 30% 0%,
+                            hsla(240, 100%, 87%, 0.35) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 100% 54%,
+                            hsla(280, 100%, 75%, 0.26) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 61% 0%,
+                            hsla(22, 100%, 77%, 0.19) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 2% 48%,
+                            hsla(240, 100%, 70%, 0.15) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 80% 100%,
+                            hsla(343, 100%, 76%, 0.17) 0px,
+                            transparent 50%
+                        );
                 }
             }
 
@@ -136,14 +283,46 @@
                         rgba(255, 255, 255, 0.8) 70%,
                         transparent 150%
                     ),
-                    radial-gradient(closest-side at center, rgba(255, 255, 255, 0.8) 90%, transparent 150%),
-                    radial-gradient(at 29% 66%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
-                    radial-gradient(at 47% 51%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
-                    radial-gradient(at 34% 34%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
-                    radial-gradient(at 74% 32%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
-                    radial-gradient(at 57% 66%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
-                    radial-gradient(at 42% 84%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
-                    radial-gradient(at 59% 10%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
+                    radial-gradient(
+                        closest-side at center,
+                        rgba(255, 255, 255, 0.8) 90%,
+                        transparent 150%
+                    ),
+                    radial-gradient(
+                        at 29% 66%,
+                        hsla(223, 100%, 65%, 0.14) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 47% 51%,
+                        hsla(210, 100%, 69%, 0.29) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 34% 34%,
+                        hsla(240, 100%, 87%, 0.35) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 74% 32%,
+                        hsla(280, 100%, 75%, 0.26) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 57% 66%,
+                        hsla(22, 100%, 77%, 0.19) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 42% 84%,
+                        hsla(240, 100%, 70%, 0.15) 0px,
+                        transparent 50%
+                    ),
+                    radial-gradient(
+                        at 59% 10%,
+                        hsla(343, 100%, 76%, 0.17) 0px,
+                        transparent 50%
+                    );
 
                 html.dark & {
                     background-image: radial-gradient(
@@ -151,13 +330,41 @@
                             theme(colors.gray.800) 50%,
                             transparent 120%
                         ),
-                        radial-gradient(at 29% 66%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
-                        radial-gradient(at 47% 51%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
-                        radial-gradient(at 34% 34%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
-                        radial-gradient(at 74% 32%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
-                        radial-gradient(at 57% 66%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
-                        radial-gradient(at 42% 84%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
-                        radial-gradient(at 59% 10%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
+                        radial-gradient(
+                            at 29% 66%,
+                            hsla(223, 100%, 65%, 0.14) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 47% 51%,
+                            hsla(210, 100%, 69%, 0.29) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 34% 34%,
+                            hsla(240, 100%, 87%, 0.35) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 74% 32%,
+                            hsla(280, 100%, 75%, 0.26) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 57% 66%,
+                            hsla(22, 100%, 77%, 0.19) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 42% 84%,
+                            hsla(240, 100%, 70%, 0.15) 0px,
+                            transparent 50%
+                        ),
+                        radial-gradient(
+                            at 59% 10%,
+                            hsla(343, 100%, 76%, 0.17) 0px,
+                            transparent 50%
+                        );
                 }
             }
         }

--- a/components/fern/features.vue
+++ b/components/fern/features.vue
@@ -1,32 +1,20 @@
 <template>
     <article id="features" class="fern-gap">
-        <div
-            class="flex flex-col md:flex-row md:justify-between items-start md:items-end gap-4 w-full mb-6 sm:mb-12"
-        >
+        <div class="mb-6 flex w-full flex-col items-start gap-4 sm:mb-12 md:flex-row md:items-end md:justify-between">
             <h2
-                class="text-5xl sm:text-6xl text-left text-gray-700 dark:text-gray-300 font-medium leading-[3.5rem] sm:leading-[4.5rem]"
+                class="text-left text-5xl font-medium leading-[3.5rem] text-gray-700 dark:text-gray-300 sm:text-6xl sm:leading-[4.5rem]"
             >
-                <span
-                    class="text-gray-500 dark:text-gray-400 font-medium text-xl"
-                    >To summarize</span
-                ><br />
+                <span class="text-xl font-medium text-gray-500 dark:text-gray-400">To summarize</span><br />
                 Only the
-                <span
-                    class="text-gradient font-semibold from-purple-500 to-sky-400"
-                    >best</span
-                >
+                <span class="text-gradient from-purple-500 to-sky-400 font-semibold">best</span>
                 <br />
                 for the bold
             </h2>
-            <p
-                class="w-full sm:w-1/2 lg:max-w-lg lg:w-full lg:pr-24 dark:text-gray-400 dark:font-medium"
-            >
-                <span class="inline-block mb-2"
-                    >For builders, inventors, and visionaries</span
-                >
+            <p class="w-full dark:font-medium dark:text-gray-400 sm:w-1/2 lg:w-full lg:max-w-lg lg:pr-24">
+                <span class="mb-2 inline-block">For builders, inventors, and visionaries</span>
                 <br />
-                We spent years studying the strengths and weaknesses of
-                JavaScript frameworks, all to deliver an exceptional experience
+                We spent years studying the strengths and weaknesses of JavaScript frameworks, all to deliver an
+                exceptional experience
             </p>
         </div>
         <div class="list">
@@ -40,35 +28,29 @@
                 <h3>Maximum Type Safety</h3>
                 <h4 class="text-blue-400">Dynamic type safety</h4>
                 <p>Built from type to runtime</p>
-                <p>
-                    Elysia learns from your codebase, adapts, and enforces your
-                    types
-                </p>
+                <p>Elysia learns from your codebase, adapts, and enforces your types</p>
             </section>
             <section>
                 <h3>Productive in a reach</h3>
                 <h4 class="text-teal-400">The best experience of today</h4>
-                <p>
-                    Ergonomically designed for humans, prioritizing DX. No technical non-sense
-                </p>
+                <p>Ergonomically designed for humans, prioritizing DX. No technical non-sense</p>
             </section>
         </div>
-        <h5 class="text-right text-base mt-6 text-gray-400/75">
-            These are the pillars we built Elysia upon,<br />to deliver the best
-            experience yet
+        <h5 class="mt-6 text-right text-base text-gray-400/75">
+            These are the pillars we built Elysia upon,<br />to deliver the best experience yet
         </h5>
     </article>
 </template>
 
 <style>
 #features {
-    @apply relative max-w-5xl w-full mx-auto mt-4 mb-12;
+    @apply relative mx-auto mb-12 mt-4 w-full max-w-5xl;
 
     & > .list {
-        @apply grid sm:grid-cols-2 lg:grid-cols-3 gap-4 z-10;
+        @apply z-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3;
 
         & > section {
-            @apply relative flex flex-col w-full rounded-3xl p-6 border border-r-blue-100 border-b-purple-100 border-t-purple-200 border-l-blue-200 dark:border-r-blue-300/40 dark:border-b-purple-300/40 dark:border-t-purple-400/50 dark:border-l-blue-400/40 transform hover:-translate-y-2 transition-all ease-out duration-200 dark:text-gray-400;
+            @apply relative flex w-full transform flex-col rounded-3xl border border-b-purple-100 border-l-blue-200 border-r-blue-100 border-t-purple-200 p-6 transition-all duration-200 ease-out hover:-translate-y-2 dark:border-b-purple-300/40 dark:border-l-blue-400/40 dark:border-r-blue-300/40 dark:border-t-purple-400/50 dark:text-gray-400;
             box-shadow: 0 7px 40px rgba(48, 160, 255, 0.075);
 
             &:hover {
@@ -88,56 +70,20 @@
             }
 
             & > h4 {
-                @apply inline-block text-base font-medium mt-0.5 mb-3 dark:text-gray-400/90;
+                @apply mb-3 mt-0.5 inline-block text-base font-medium dark:text-gray-400/90;
             }
 
             &:nth-child(1) {
                 @apply bg-white dark:bg-gray-900;
-                background-image: radial-gradient(
-                        closest-side at center,
-                        rgba(255, 255, 255, 1) 70%,
-                        transparent 150%
-                    ),
-                    radial-gradient(
-                        closest-side at center,
-                        rgba(255, 255, 255, 1) 90%,
-                        transparent 150%
-                    ),
-                    radial-gradient(
-                        at 9% 67%,
-                        hsla(223, 100%, 65%, 0.14) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 22% 0%,
-                        hsla(210, 100%, 69%, 0.29) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 97% 49%,
-                        hsla(240, 100%, 87%, 0.35) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 100% 75%,
-                        hsla(280, 100%, 75%, 0.26) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 75% 100%,
-                        hsla(22, 100%, 77%, 0.19) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 40% 100%,
-                        hsla(240, 100%, 70%, 0.15) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 72% 0%,
-                        hsla(343, 100%, 76%, 0.17) 0px,
-                        transparent 50%
-                    );
+                background-image: radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 70%, transparent 150%),
+                    radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 90%, transparent 150%),
+                    radial-gradient(at 9% 67%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
+                    radial-gradient(at 22% 0%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
+                    radial-gradient(at 97% 49%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
+                    radial-gradient(at 100% 75%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
+                    radial-gradient(at 75% 100%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
+                    radial-gradient(at 40% 100%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
+                    radial-gradient(at 72% 0%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
 
                 html.dark & {
                     background-image: radial-gradient(
@@ -145,91 +91,27 @@
                             theme(colors.gray.800) 70%,
                             transparent 150%
                         ),
-                        radial-gradient(
-                            at 9% 67%,
-                            hsla(223, 100%, 65%, 0.14) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 22% 0%,
-                            hsla(210, 100%, 69%, 0.29) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 97% 49%,
-                            hsla(240, 100%, 87%, 0.35) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 100% 75%,
-                            hsla(280, 100%, 75%, 0.26) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 75% 100%,
-                            hsla(22, 100%, 77%, 0.19) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 40% 100%,
-                            hsla(240, 100%, 70%, 0.15) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 72% 0%,
-                            hsla(343, 100%, 76%, 0.17) 0px,
-                            transparent 50%
-                        );
+                        radial-gradient(at 9% 67%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
+                        radial-gradient(at 22% 0%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
+                        radial-gradient(at 97% 49%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
+                        radial-gradient(at 100% 75%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
+                        radial-gradient(at 75% 100%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
+                        radial-gradient(at 40% 100%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
+                        radial-gradient(at 72% 0%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
                 }
             }
 
             &:nth-child(2) {
                 @apply bg-white dark:bg-gray-900;
-                background-image: radial-gradient(
-                        closest-side at center,
-                        rgba(255, 255, 255, 1) 70%,
-                        transparent 150%
-                    ),
-                    radial-gradient(
-                        closest-side at center,
-                        rgba(255, 255, 255, 1) 90%,
-                        transparent 150%
-                    ),
-                    radial-gradient(
-                        at 7% 95%,
-                        hsla(223, 100%, 65%, 0.14) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 89% 10%,
-                        hsla(210, 100%, 69%, 0.29) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 30% 0%,
-                        hsla(240, 100%, 87%, 0.35) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 100% 54%,
-                        hsla(280, 100%, 75%, 0.26) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 61% 0%,
-                        hsla(22, 100%, 77%, 0.19) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 2% 48%,
-                        hsla(240, 100%, 70%, 0.15) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 80% 100%,
-                        hsla(343, 100%, 76%, 0.17) 0px,
-                        transparent 50%
-                    );
+                background-image: radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 70%, transparent 150%),
+                    radial-gradient(closest-side at center, rgba(255, 255, 255, 1) 90%, transparent 150%),
+                    radial-gradient(at 7% 95%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
+                    radial-gradient(at 89% 10%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
+                    radial-gradient(at 30% 0%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
+                    radial-gradient(at 100% 54%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
+                    radial-gradient(at 61% 0%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
+                    radial-gradient(at 2% 48%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
+                    radial-gradient(at 80% 100%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
 
                 html.dark & {
                     background-image: radial-gradient(
@@ -237,41 +119,13 @@
                             theme(colors.gray.800) 70%,
                             transparent 150%
                         ),
-                        radial-gradient(
-                            at 7% 95%,
-                            hsla(223, 100%, 65%, 0.14) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 89% 10%,
-                            hsla(210, 100%, 69%, 0.29) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 30% 0%,
-                            hsla(240, 100%, 87%, 0.35) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 100% 54%,
-                            hsla(280, 100%, 75%, 0.26) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 61% 0%,
-                            hsla(22, 100%, 77%, 0.19) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 2% 48%,
-                            hsla(240, 100%, 70%, 0.15) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 80% 100%,
-                            hsla(343, 100%, 76%, 0.17) 0px,
-                            transparent 50%
-                        );
+                        radial-gradient(at 7% 95%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
+                        radial-gradient(at 89% 10%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
+                        radial-gradient(at 30% 0%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
+                        radial-gradient(at 100% 54%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
+                        radial-gradient(at 61% 0%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
+                        radial-gradient(at 2% 48%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
+                        radial-gradient(at 80% 100%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
                 }
             }
 
@@ -282,46 +136,14 @@
                         rgba(255, 255, 255, 0.8) 70%,
                         transparent 150%
                     ),
-                    radial-gradient(
-                        closest-side at center,
-                        rgba(255, 255, 255, 0.8) 90%,
-                        transparent 150%
-                    ),
-                    radial-gradient(
-                        at 29% 66%,
-                        hsla(223, 100%, 65%, 0.14) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 47% 51%,
-                        hsla(210, 100%, 69%, 0.29) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 34% 34%,
-                        hsla(240, 100%, 87%, 0.35) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 74% 32%,
-                        hsla(280, 100%, 75%, 0.26) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 57% 66%,
-                        hsla(22, 100%, 77%, 0.19) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 42% 84%,
-                        hsla(240, 100%, 70%, 0.15) 0px,
-                        transparent 50%
-                    ),
-                    radial-gradient(
-                        at 59% 10%,
-                        hsla(343, 100%, 76%, 0.17) 0px,
-                        transparent 50%
-                    );
+                    radial-gradient(closest-side at center, rgba(255, 255, 255, 0.8) 90%, transparent 150%),
+                    radial-gradient(at 29% 66%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
+                    radial-gradient(at 47% 51%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
+                    radial-gradient(at 34% 34%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
+                    radial-gradient(at 74% 32%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
+                    radial-gradient(at 57% 66%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
+                    radial-gradient(at 42% 84%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
+                    radial-gradient(at 59% 10%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
 
                 html.dark & {
                     background-image: radial-gradient(
@@ -329,41 +151,13 @@
                             theme(colors.gray.800) 50%,
                             transparent 120%
                         ),
-                        radial-gradient(
-                            at 29% 66%,
-                            hsla(223, 100%, 65%, 0.14) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 47% 51%,
-                            hsla(210, 100%, 69%, 0.29) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 34% 34%,
-                            hsla(240, 100%, 87%, 0.35) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 74% 32%,
-                            hsla(280, 100%, 75%, 0.26) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 57% 66%,
-                            hsla(22, 100%, 77%, 0.19) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 42% 84%,
-                            hsla(240, 100%, 70%, 0.15) 0px,
-                            transparent 50%
-                        ),
-                        radial-gradient(
-                            at 59% 10%,
-                            hsla(343, 100%, 76%, 0.17) 0px,
-                            transparent 50%
-                        );
+                        radial-gradient(at 29% 66%, hsla(223, 100%, 65%, 0.14) 0px, transparent 50%),
+                        radial-gradient(at 47% 51%, hsla(210, 100%, 69%, 0.29) 0px, transparent 50%),
+                        radial-gradient(at 34% 34%, hsla(240, 100%, 87%, 0.35) 0px, transparent 50%),
+                        radial-gradient(at 74% 32%, hsla(280, 100%, 75%, 0.26) 0px, transparent 50%),
+                        radial-gradient(at 57% 66%, hsla(22, 100%, 77%, 0.19) 0px, transparent 50%),
+                        radial-gradient(at 42% 84%, hsla(240, 100%, 70%, 0.15) 0px, transparent 50%),
+                        radial-gradient(at 59% 10%, hsla(343, 100%, 76%, 0.17) 0px, transparent 50%);
                 }
             }
         }

--- a/components/fern/features.vue
+++ b/components/fern/features.vue
@@ -41,16 +41,15 @@
                 <h4 class="text-blue-400">Dynamic type safety</h4>
                 <p>Built from type to runtime</p>
                 <p>
-                    Elysia learn from your codebase, adapt, enforce with your
-                    type
+                    Elysia learns from your codebase, adapts, and enforces your
+                    types
                 </p>
             </section>
             <section>
                 <h3>Productive in a reach</h3>
                 <h4 class="text-teal-400">The best experience of today</h4>
                 <p>
-                    Ergonomically designed for human, putting DX at the
-                    priority. No technical non-sense
+                    Ergonomically designed for humans, prioritizing DX. No technical nonsense
                 </p>
             </section>
         </div>

--- a/components/fern/features.vue
+++ b/components/fern/features.vue
@@ -41,16 +41,15 @@
                 <h4 class="text-blue-400">Dynamic type safety</h4>
                 <p>Built from type to runtime</p>
                 <p>
-                    Elysia learn from your codebase, adapt, enforce with your
-                    type
+                    Elysia learns from your codebase, adapts, and enforces your
+                    types
                 </p>
             </section>
             <section>
                 <h3>Productive in a reach</h3>
                 <h4 class="text-teal-400">The best experience of today</h4>
                 <p>
-                    Ergonomically designed for human, putting DX at the
-                    priority. No technical non-sense
+                    Ergonomically designed for humans, prioritizing DX. No technical non-sense
                 </p>
             </section>
         </div>

--- a/components/fern/sponsor.vue
+++ b/components/fern/sponsor.vue
@@ -10,11 +10,10 @@
         >
             Elysia is
             <span class="text-gray-700 dark:text-gray-200 font-medium"
-                >not own by an organization</span
-            >
-            but is driven by the community.
+                >not owned by an organization</span
+            >, but is driven by the community.
             <br />
-            Elysia development is only possible thanks to your support
+            Elysia development is only possible thanks to your support.
         </p>
         <div class="flex sm:justify-center my-8">
             <a

--- a/components/fern/test.vue
+++ b/components/fern/test.vue
@@ -9,7 +9,7 @@
                         Test with
                         <span
                             class="text-gradient font-semibold from-violet-500 to-sky-400"
-                            >confidence</span
+                            >Confidence</span
                         >
                     </h2>
                     <h3 class="sm:flex items-center text-2xl">
@@ -58,11 +58,11 @@
                     </h3>
                 </div>
                 <p class="lg:max-w-md leading-normal">
-                    Elysia provide a type-safe layer for interact and test your
-                    server from routes to parameters.
+                    Elysia provides a type-safe layer to interact with and test your
+                    server, from routes to parameters.
                 </p>
                 <p class="lg:max-w-md leading-normal">
-                    With auto-completion, you can easily write tests for server
+                    With auto-completion, you can easily write tests for the server
                     without any hassle.
                 </p>
                 <!-- <slot name="test-script" /> -->

--- a/docs/at-glance.md
+++ b/docs/at-glance.md
@@ -34,7 +34,7 @@ const demo2 = new Elysia()
 # At glance
 Elysia is an ergonomic web framework for building backend servers with Bun.
 
-Designed with simplicity and type safety in mind with familiar API with extensive support for TypeScript, optimized for Bun.
+Designed with simplicity and type-safety in mind, Elysia has a familiar API with extensive support for TypeScript, optimized for Bun.
 
 Here's a simple hello world in Elysia.
 
@@ -70,16 +70,16 @@ Navigate to [localhost:3000](http://localhost:3000/) and it should show 'Hello E
 ::: tip
 Hover over the code snippet to see the type definition.
 
-In the mock browser, click on path highlight in blue to change path to preview a response and
+In the mock browser, click on the path highlighted in blue to change paths and preview the response.
 
-Elysia can run on browser and the results you see are actually ran using Elysia.
+Elysia can run in the browser, and the results you see are actually run using Elysia.
 :::
 
 ## Performance
 
 Building on Bun and extensive optimization like Static Code Analysis allows Elysia to generate optimized code on the fly.
 
-Elysia can outperform most of the web frameworks available today<a href="#ref-1"><sup>[1]</sup></a>, and even match the performance of Golang and Rust framework<a href="#ref-2"><sup>[2]</sup></a>.
+Elysia can outperform most of the web frameworks available today<a href="#ref-1"><sup>[1]</sup></a>, and even match the performance of Golang and Rust frameworks<a href="#ref-2"><sup>[2]</sup></a>.
 
 | Framework     | Runtime | Average     | Plain Text | Dynamic Parameters | JSON Body  |
 | ------------- | ------- | ----------- | ---------- | ------------------ | ---------- |
@@ -99,7 +99,7 @@ Elysia can outperform most of the web frameworks available today<a href="#ref-1"
 
 Elysia is designed to help you write less TypeScript.
 
-Elysia's Type System is fine-tuned to infer your code into type automatically without needing to write explicit TypeScript while providing type-safety for both runtime and compile time to provide you with the most ergonomic developer experience.
+Elysia's Type System is fine-tuned to infer your code into types automatically, without needing to write explicit TypeScript, while providing type-safety at both runtime and compile time to provide you with the most ergonomic developer experience.
 
 Take a look at this example:
 
@@ -114,7 +114,7 @@ new Elysia()
 
 <br>
 
-The above code create a path parameter "id", the value that replaces `:id` will be passed to `params.id` both in runtime and type without manual type declaration.
+The above code creates a path parameter "id". The value that replaces `:id` will be passed to `params.id` both at runtime and in types without manual type declaration.
 
 <Playground
     :elysia="demo2"
@@ -128,13 +128,13 @@ The above code create a path parameter "id", the value that replaces `:id` will 
     }"
 />
 
-Elysia's goal is to help you write less TypeScript and focus more on Business logic. Let the complex types be handled by the framework.
+Elysia's goal is to help you write less TypeScript and focus more on business logic. Let the complex types be handled by the framework.
 
 TypeScript is not needed to use Elysia, but it's recommended to use Elysia with TypeScript.
 
 ## Type Integrity
 
-To take a step further, Elysia provide **Elysia.t**, a schema builder to validate type and value in both runtime and compile-time to create a single source of truth for your data-type.
+To take a step further, Elysia provides **Elysia.t**, a schema builder to validate types and values at both runtime and compile-time to create a single source of truth for your data-type.
 
 Let's modify the previous code to accept only a numeric value instead of a string.
 
@@ -151,19 +151,19 @@ new Elysia()
     .listen(3000)
 ```
 
-This code ensures that our path parameter **id**, will always be a numeric string and then transforms it into a number automatically in both runtime and compile-time (type-level).
+This code ensures that our path parameter **id** will always be a numeric string and then transforms it into a number automatically at both runtime and compile-time (type-level).
 
 ::: tip
 Hover over "id" in the above code snippet to see a type definition.
 :::
 
-With Elysia schema builder, we can ensure type safety like a strong-typed language with a single source of truth.
+With Elysia's schema builder, we can ensure type safety like a strongly-typed language with a single source of truth.
 
 ## Standard
 
 Elysia adopts many standards by default, like OpenAPI, and WinterCG compliance, allowing you to integrate with most of the industry standard tools or at least easily integrate with tools you are familiar with.
 
-For instance, as Elysia adopts OpenAPI by default, generating a documentation with Swagger is as easy as adding a one-liner:
+For instance, because Elysia adopts OpenAPI by default, generating documentation with Swagger is as easy as adding a one-liner:
 
 ```typescript twoslash
 import { Elysia, t } from 'elysia'
@@ -234,17 +234,17 @@ const { data } = await app.user({ id: 617 }).get()
 console.log(data)
 ```
 
-With Eden, you can use the existing Elysia types to query Elysia server **without code generation** and synchronize types for both frontend and backend automatically.
+With Eden, you can use the existing Elysia types to query an Elysia server **without code generation** and synchronize types for both frontend and backend automatically.
 
 Elysia is not only about helping you create a confident backend but for all that is beautiful in this world.
 
 ## Platform Agnostic
 
-Elysia was designed but was **not limited to Bun**. Being [WinterCG compliant](https://wintercg.org/) allows you to deploy the Elysia server on Cloudflare Worker, Vercel Edge Function, and most other runtimes that support Web Standard Request.
+Elysia was designed for Bun, but is  **not limited to Bun**. Being [WinterCG compliant](https://wintercg.org/) allows you to deploy Elysia servers on Cloudflare Workers, Vercel Edge Functions, and most other runtimes that support Web Standard Requests.
 
 ## Our Community
 
-If you have questions or get stuck about Elysia, feel free to ask our community on GitHub Discussions, Discord, and Twitter.
+If you have questions or get stuck regarding Elysia, feel free to ask our community on GitHub Discussions, Discord, and Twitter.
 
 <Deck>
     <Card title="Discord" href="https://discord.gg/eaFJ2KDJck">
@@ -260,6 +260,6 @@ If you have questions or get stuck about Elysia, feel free to ask our community 
 
 ---
 
-<small id="ref-1">1. Measure in requests/second. The benchmark for parsing query, path parameter and set response header on Debian 11, Intel i7-13700K tested on Bun 0.7.2 on 6 Aug 2023. See the benchmark condition [here](https://github.com/SaltyAom/bun-http-framework-benchmark/tree/c7e26fe3f1bfee7ffbd721dbade10ad72a0a14ab#results).</small>
+<small id="ref-1">1. Measured in requests/second. The benchmark for parsing query, path parameter and set response header on Debian 11, Intel i7-13700K tested on Bun 0.7.2 on 6 Aug 2023. See the benchmark condition [here](https://github.com/SaltyAom/bun-http-framework-benchmark/tree/c7e26fe3f1bfee7ffbd721dbade10ad72a0a14ab#results).</small>
 
 <small id="ref-2">2. Based on [TechEmpower Benchmark round 22](https://www.techempower.com/benchmarks/#section=data-r22&hw=ph&test=composite).</small>


### PR DESCRIPTION
This PR fixes a handful of grammatical issues on the Elysia homepage and "at-glance" page. Note that we probably also need to update `.vitepress/config.ts` to rename the latter page in the sidebar to "At a glance" in addition to updating its url as a follow-up (with a redirect for the old url to prevent bookmarked links from breaking). But given that this is my first PR for this project, I wanted to start just the smaller copy changes before trying anything more substantial.

I was not able to get automatic code formatting to work locally, so likely some whitespace changes will need to be reformatted.