### PR TITLE
📘 chore: typo

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -105,7 +105,7 @@ This is to ensure developers end up with a performant web server they intend to 
 -   [Elysia CQRS](https://github.com/jassix/elysia-cqrs) - Elysia plugin for CQRS pattern
 -   [Nice Logger](https://github.com/tanishqmanuja/nice-logger) - Not the nicest, but a pretty nice and sweet logger for Elysia.
 
-## Complementaray projects:
+## Complementary projects:
 -   [prismabox](https://github.com/m1212e/prismabox) - Generator for typebox schemes based on your database models, works well with elysia
 ---
 


### PR DESCRIPTION
Spelling mistake fix on the plugins overview page.