### PR TITLE
Fix typo in mount.md

### DIFF
--- a/docs/patterns/mount.md
+++ b/docs/patterns/mount.md
@@ -57,7 +57,7 @@ import { Elysia } from 'elysia'
 import { Hono } from 'hono'
 
 const elysia = new Elysia()
-    .get('/Hello from Elysia inside Hono inside Elysia')
+    .get('/', () => 'Hello from Elysia inside Hono inside Elysia')
 
 const hono = new Hono()
     .get('/', (c) => c.text('Hello from Hono!'))


### PR DESCRIPTION
I have no experience with either Elysia or Hono. However, I briefly set up the case locally, and it seems that, as documented, it leads to a syntax error.