### PR TITLE
General fixes on the pages from `Getting Started` and `Essential`

### DIFF
--- a/docs/eden/installation.md
+++ b/docs/eden/installation.md
@@ -118,7 +118,7 @@ npm why elysia
 
 And output should contain only one elysia version on top-level:
 
-```tree
+```
 elysia@1.1.12
 node_modules/elysia
   elysia@"1.1.25" from the root project

--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -240,12 +240,12 @@ class AuthService {
 }
 ```
 
-However we recommend to avoid this if possible, and use [Elysia as a service](✅-do-use-elysia-instance-as-a-service) instead.
+However we recommend to avoid this if possible, and use [Elysia as a service](#✅-do-use-elysia-as-a-controller) instead.
 
 You may find more about [InferContext](/essential/handler#infercontext) in [Essential: Handler](/essential/handler).
 
 ## Model
-Model or [DTO (Data Transfer Object)](https://en.wikipedia.org/wiki/Data_transfer_object) is handle by [Elysia.t (Validation)](/validation/overview.html#data-validation).
+Model or [DTO (Data Transfer Object)](https://en.wikipedia.org/wiki/Data_transfer_object) is handle by [Elysia.t (Validation)](/essential/validation.html#elysia-type).
 
 Elysia has a validation system built-in which can infers type from your code and validate it at runtime.
 
@@ -358,7 +358,7 @@ const models = AuthModel.models
 ```
 
 ### Model Injection
-Though this is optional, if you are strictly following MVC pattern, you may want to inject like a service into a controller. We recommended using [Elysia reference model](/validation/reference-model.html#reference-model)
+Though this is optional, if you are strictly following MVC pattern, you may want to inject like a service into a controller. We recommended using [Elysia reference model](/essential/validation#reference-model)
 
 Using Elysia's model reference
 ```typescript twoslash
@@ -389,7 +389,7 @@ const UserController = new Elysia({ prefix: '/auth' })
 
 This approach provide several benefits:
 1. Allow us to name a model and provide auto-completion.
-2. Modify schema for later usage, or perform [remapping](/patterns/remapping.html#remapping).
+2. Modify schema for later usage, or perform a [remap](/essential/handler.html#remap).
 3. Show up as "models" in OpenAPI compliance client, eg. Swagger.
 4. Improve TypeScript inference speed as model type will be cached during registration.
 

--- a/docs/essential/handler.md
+++ b/docs/essential/handler.md
@@ -551,7 +551,7 @@ new Elysia()
 <Playground :elysia="demo2" />
 
 ::: tip
-Beware that we cannot use state value before assign.
+Beware that we cannot use a state value before assign.
 
 Elysia registers state values into the store automatically without explicit type or additional TypeScript generic needed.
 :::
@@ -589,9 +589,9 @@ new Elysia()
 - Make sure to assign a value before using it in a handler.
 
 ## Derive
-Retrieve values from existing properties in **Context** and assign an new properties.
+Retrieve values from existing properties in **Context** and assign new properties.
 
-Derive assigns when request happens **at transform lifecycle** allowing us to "derive" <small>create a new property from existing property</small>.
+Derive assigns when request happens **at transform lifecycle** allowing us to "derive" <small>(create new properties from existing properties)</small>.
 
 ```typescript twoslash
 import { Elysia } from 'elysia'
@@ -648,7 +648,7 @@ new Elysia()
 - When you need to access request properties like **headers**, **query**, **body** with validation
 
 ### Key takeaway
-- **resolve is called at beforehandle, or after validation** happens. Elysia can safely confirm the type of request property resulting in as **typed**.
+- **resolve is called at beforeHandle, or after validation** happens. Elysia can safely confirm the type of request property resulting in as **typed**.
 
 ### Error from resolve/derive
 As resolve and derive is based on **transform** and **beforeHandle** lifecycle, we can return an error from resolve and derive. If error is returned from **derive**, Elysia will return early exit and return the error as response.
@@ -925,7 +925,7 @@ const app = new Elysia()
 
 The field can accept anything ranging from string to function, allowing us to create a custom life cycle event.
 
-macro will be executed in order from top-to-bottom according to definition in hook, ensure that the stack should be handle in correct order.
+**macro** will be executed in order from top-to-bottom according to definition in hook, ensure that the stack should be handle in correct order.
 
 ### Parameters
 

--- a/docs/essential/life-cycle.md
+++ b/docs/essential/life-cycle.md
@@ -427,7 +427,7 @@ The response should be listed as follows:
 
 ### Guard
 
-When we need to apply the same before handle to multiple routes, we can use [guard](#guard) to apply the same before handle to multiple routes.
+When we need to apply the same before handle to multiple routes, we can use `guard` to apply the same before handle to multiple routes.
 
 ```typescript
 import { Elysia } from 'elysia'

--- a/docs/essential/life-cycle.md
+++ b/docs/essential/life-cycle.md
@@ -459,11 +459,11 @@ new Elysia()
 
 ## Resolve
 
-A "safe" version of [derive](/life-cycle/before-handle#derive).
+A "safe" version of [derive](#derive).
 
 Designed to append new value to context after validation process storing in the same stack as **beforeHandle**.
 
-Resolve syntax is identical to [derive](/life-cycle/before-handle#derive), below is an example of retrieving a bearer header from the Authorization plugin.
+Resolve syntax is identical to [derive](#derive), below is an example of retrieving a bearer header from the Authorization plugin.
 
 ```typescript
 import { Elysia, t } from 'elysia'
@@ -764,7 +764,7 @@ Properties of `error` code is based on the properties of `error`, the said prope
 
 ### Local Error
 
-Same as others life-cycle, we provide an error into an [scope](/essential/scope) using guard:
+Same as others life-cycle, we provide an error into an [scope](/essential/plugin.html#scope) using guard:
 
 ```typescript
 import { Elysia } from 'elysia'

--- a/docs/essential/plugin.md
+++ b/docs/essential/plugin.md
@@ -607,7 +607,7 @@ const main = new Elysia()
 
 Sometimes we want to reapply plugin to parent instance as well but as it's limited by `scoped` mechanism, it's limited to 1 parent only.
 
-To apply to the parent instance, we need to **"lift the scope up** to the parent instance, and `as` is the perfect method to do so.
+To apply to the parent instance, we need to **lift the scope up** to the parent instance, and `as` is the perfect method to do so.
 
 Which means if you have `local` scope, and want to apply it to the parent instance, you can use `as('plugin')` to lift it up.
 ```typescript twoslash
@@ -636,7 +636,7 @@ const parent = new Elysia()
 
 ### Descendant
 
-By default plugin will only **apply hook to itself and descendants** only.
+By default plugin will **apply hook to itself and descendants** only.
 
 If the hook is registered in a plugin, instances that inherit the plugin will **NOT** inherit hooks and schema.
 

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -530,7 +530,7 @@ But also useful for simulating or creating unit tests.
 
 ## 404
 
-If no path matches the defined routes, Elysia will pass the request to [error](/life-cycle/on-error) life cycle before returning a **"NOT_FOUND"** with an HTTP status of 404.
+If no path matches the defined routes, Elysia will pass the request to [error](/essential/life-cycle.html#on-error) life cycle before returning a **"NOT_FOUND"** with an HTTP status of 404.
 
 We can handle a custom 404 error by returning a value from 'error` life cycle like this:
 
@@ -557,7 +557,7 @@ When navigating to your web server, you should see the result as follows:
 | /    | POST   | Route not found :\( |
 | /hi  | GET    | Route not found :\( |
 
-You can learn more about life cycle and error handling in [Life Cycle Events](/essential/life-cycle#events) and [Error Handling](/life-cycle/on-error).
+You can learn more about life cycle and error handling in [Life Cycle Events](/essential/life-cycle#events) and [Error Handling](/essential/life-cycle.html#on-error).
 
 ::: tip
 HTTP Status is used to indicate the type of response. By default if everything is correct, the server will return a '200 OK' status code (If a route matches and there is no error, Elysia will return 200 as default)
@@ -625,7 +625,7 @@ new Elysia()
     .listen(3000)
 ```
 
-You may find more information about grouped guards in [scope](/essential/scope.html).
+You may find more information about grouped guards in [scope](/essential/plugin.html#scope).
 
 ### Prefix
 

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -532,7 +532,7 @@ But also useful for simulating or creating unit tests.
 
 If no path matches the defined routes, Elysia will pass the request to [error](/essential/life-cycle.html#on-error) life cycle before returning a **"NOT_FOUND"** with an HTTP status of 404.
 
-We can handle a custom 404 error by returning a value from 'error` life cycle like this:
+We can handle a custom 404 error by returning a value from `error` life cycle like this:
 
 ```typescript twoslash
 import { Elysia } from 'elysia'

--- a/docs/essential/validation.md
+++ b/docs/essential/validation.md
@@ -549,7 +549,7 @@ new Elysia()
 
 This code tells Elysia to validate an incoming HTTP body, make sure that the body is String, and if it is String, then allow it to flow through the request pipeline and handler.
 
-If the shape doesn't match, then it will throw an error, into [Error Life Cycle](/essential/life-cycle.html#events).
+If the shape doesn't match, then it will throw an error, into [Error Life Cycle](/essential/life-cycle.html#on-error).
 
 ![Elysia Life Cycle](/assets/lifecycle.webp)
 
@@ -1154,7 +1154,7 @@ For additional information, you can find the full source code of the type system
 There are 2 ways to provide a custom error message when the validation fails:
 
 1. inline `error` property
-2. Using [onError](/life-cycle/on-error) event
+2. Using [onError](/essential/life-cycle.html#on-error) event
 
 ### Error Property
 
@@ -1399,7 +1399,7 @@ Expected value to be an object
 
 ### onError
 
-We can customize the behavior of validation based on [onError](/life-cycle/on-error) event by narrowing down the error code call "**VALIDATION**".
+We can customize the behavior of validation based on [onError](/essential/life-cycle.html#on-error) event by narrowing down the error code call "**VALIDATION**".
 
 ```typescript twoslash
 import { Elysia, t } from 'elysia'

--- a/docs/essential/validation.md
+++ b/docs/essential/validation.md
@@ -809,10 +809,6 @@ y: 200
 
 See [JSON Schema 7 specification](https://json-schema.org/draft/2020-12/json-schema-validation) For more explanation for each attribute.
 
----
-
-<br>
-
 ## Honorable Mention
 
 The following are common patterns that are often found useful when creating a schema.

--- a/docs/key-concept.md
+++ b/docs/key-concept.md
@@ -169,7 +169,7 @@ const server = new Elysia()
 
 This will prevent the `ip` property from being call multiple time by applying deduplication using an unique name.
 
-Once name is provided, the instance will be come a **singleton**. Allowing Elysia to apply plugin deduplication.
+Once `name` is provided, the instance will become a **singleton**. Allowing Elysia to apply plugin deduplication.
 
 Allowing us to reuse the same instance multiple time without performance penalty.
 
@@ -196,7 +196,7 @@ const app = new Elysia()
 	})
 ```
 
-If possible, **always use a inline function** to provide an accurate type inference.
+If possible, **always use an inline function** to provide an accurate type inference.
 
 If you need to apply a separate function, eg. MVC's controller pattern. It's recommended to destructure properties from inline function to prevent unnecessary type inference.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1948,7 +1948,7 @@ export const note = new Elysia({ prefix: '/note' })
     )
 ```
 
-Now let's import, and apply `userService`, `getUserId` to apply authorization to the **note** controller.
+Now let's import, and use `userService`, `getUserId` to apply authorization to the **note** controller.
 
 ```typescript twoslash [note.ts]
 // @errors: 2392 2300 2403 2345 2698
@@ -2379,7 +2379,7 @@ Elysia supports OpenTelemetry by default with the `@elysiajs/opentelemetry` plug
 bun add @elysiajs/opentelemetry
 ```
 
-Make sure to have an OpenTelemetry collector running otherwise we will be using Jaeger using docker.
+Make sure to have an OpenTelemetry collector running otherwise we will be using Jaeger from docker.
 
 ```bash
 docker run --name jaeger \


### PR DESCRIPTION
This PR is a set of small fixes on all pages from the sections `Getting Started` and `Essential`.
I'll work later on the rest of the pages.

I'm opening a single PR for all of them because I think it'll be easier to review (just check the individual commits) - if someone prefers, I can split it into smaller PRs.

- [chore: avoid warning for tree language not loaded](https://github.com/elysiajs/documentation/commit/ddbf547dbef5b60eefb9ac19281a696eaad34580)
Currently, there is no syntax highlight for `tree` ([see on prod](https://elysiajs.com/eden/installation)), so I just removed `tree` to suppress this warning.
(https://github.com/elysiajs/documentation/commit/ddbf547dbef5b60eefb9ac19281a696eaad34580)
<img width="662" alt="image" src="https://github.com/user-attachments/assets/8156a4e1-21a1-466f-af61-ebfc344ac9e6" />

- [fix break links on the pages from Getting Started and Essential](https://github.com/elysiajs/documentation/commit/2d484734355ec468559b3a8b43fb58c0670fa37f)

- [fix typos and formatting on pages from Getting Started and Essential](https://github.com/elysiajs/documentation/commit/f9ef825b67c707fa6cffdbf5066d8d18b887055e)

- [remove an unnecessary section divider](https://github.com/elysiajs/documentation/commit/07e4b612cf93fee68bb84ac6b6e4531f0fd2862c)
There is this (probably) unintentional divider.
<img width="776" alt="image" src="https://github.com/user-attachments/assets/a64a8077-37f5-4cde-b9e8-7f362fb6d975" />
