### PR TITLE
General fixes on the pages from `Patterns` to `Integration`

### DIFF
--- a/docs/eden/installation.md
+++ b/docs/eden/installation.md
@@ -243,7 +243,7 @@ import { a, b } from '@/controllers'
 ```
 
 #### Scope
-We recommended to use add a **scope** prefix for each modules in your monorepo to avoid any confusion and conflict that may happen.
+We recommended to add a **scope** prefix for each modules in your monorepo to avoid any confusion and conflict that may happen.
 
 ```json
 {

--- a/docs/eden/treaty/config.md
+++ b/docs/eden/treaty/config.md
@@ -151,7 +151,7 @@ headers function accepts 2 parameters:
 - options `RequestInit`: Parameters that passed through 2nd parameter of fetch
 
 ### Array
-You may define a headers function as an array if multiple condition is need.
+You may define a headers function as an array if multiple conditions are need.
 
 ```typescript
 treaty<App>('localhost:3000', {
@@ -166,7 +166,7 @@ treaty<App>('localhost:3000', {
 })
 ```
 
-Eden Treaty will **run all functions** and even if the value is already returns.
+Eden Treaty will **run all functions** even if the value is already returned.
 
 ## Headers Priority
 Eden Treaty will prioritize the order headers if duplicated as follows:
@@ -240,7 +240,7 @@ If value is returned, Eden Treaty will perform a **shallow merge** for returned 
 - options `RequestInit`: Parameters that passed through 2nd parameter of fetch
 
 ### Array
-You may define an onRequest function as an array if multiple condition is need.
+You may define an onRequest function as an array if multiples conditions are need.
 
 ```typescript
 treaty<App>('localhost:3000', {
@@ -257,7 +257,7 @@ treaty<App>('localhost:3000', {
 })
 ```
 
-Eden Treaty will **run all functions** and even if the value is already returns.
+Eden Treaty will **run all functions** even if the value is already returned.
 
 ## onResponse
 Intercept and modify fetch's response or return a new value.
@@ -272,10 +272,10 @@ treaty<App>('localhost:3000', {
 ```
 
 **onRequest** accepts 1 parameter:
-- response `Response` - Web Standard Response normally return from `fetch`
+- response `Response` - Web Standard Response normally returned from `fetch`
 
 ### Array
-You may define an onResponse function as an array if multiple condition is need.
+You may define an onResponse function as an array if multiple conditions are need.
 
 ```typescript
 treaty<App>('localhost:3000', {

--- a/docs/eden/treaty/config.md
+++ b/docs/eden/treaty/config.md
@@ -70,8 +70,8 @@ This patterns is recommended for performing unit tests, or creating a type-safe 
 - [fetch](#fetch) - add default parameters to fetch intialization (RequestInit)
 - [headers](#headers) - define default headers
 - [fetcher](#fetcher) - custom fetch function eg. Axios, unfetch
-- [onRequest](#on-request) - Intercept and modify fetch request before firing
-- [onResponse](#on-response) - Intercept and modify fetch's response
+- [onRequest](#onrequest) - Intercept and modify fetch request before firing
+- [onResponse](#onresponse) - Intercept and modify fetch's response
 
 ## Fetch
 Default parameters append to 2nd parameters of fetch extends type of **Fetch.RequestInit**.
@@ -287,4 +287,4 @@ treaty<App>('localhost:3000', {
     ]
 })
 ```
-Unlike [headers](#headers) and [onRequest](#on-request), Eden Treaty will loop through functions until a returned value is found or error thrown, the returned value will be use as a new response.
+Unlike [headers](#headers) and [onRequest](#onrequest), Eden Treaty will loop through functions until a returned value is found or error thrown, the returned value will be use as a new response.

--- a/docs/eden/treaty/legacy.md
+++ b/docs/eden/treaty/legacy.md
@@ -252,7 +252,7 @@ chat.subscribe((message) => {
 chat.send('hello from client')
 ```
 
-We can use [schema](/essential/schema) to enforce type-safety on WebSockets, just like a normal route.
+We can use [schema](/integrations/cheat-sheet#schema) to enforce type-safety on WebSockets, just like a normal route.
 
 ---
 

--- a/docs/integrations/cheat-sheet.md
+++ b/docs/integrations/cheat-sheet.md
@@ -47,7 +47,7 @@ new Elysia()
 ## Path Parameter
 Using dynamic path parameter
 
-See [Path](/essential/path.html)
+See [Path](/essential/route.html#path-type)
 
 ```typescript
 import { Elysia } from 'elysia'
@@ -177,7 +177,7 @@ new Elysia()
 ## Guard
 Enforce a data type of sub routes
 
-See [Scope](/essential/scope.html#guard)
+See [Scope](/essential/plugin.html#scope)
 
 ```typescript twoslash
 // @errors: 2345
@@ -197,7 +197,7 @@ new Elysia()
 ## Customize context
 Add custom variable to route context
 
-See [Context](/essential/context.html)
+See [Context](/essential/handler.html#context)
 
 ```typescript
 import { Elysia } from 'elysia'
@@ -266,7 +266,7 @@ new Elysia()
 ## OpenAPI documentation
 Create interactive documentation using Scalar (or optionally Swagger)
 
-See [Documentation](/patterns/openapi)
+See [swagger](/plugins/swagger.html)
 
 ```typescript
 import { Elysia } from 'elysia'
@@ -305,7 +305,7 @@ describe('Elysia', () => {
 ## Custom body parser
 Create custom logic for parsing body
 
-See [Parse](/life-cycle/parse.html)
+See [Parse](/essential/life-cycle.html#parse)
 
 ```typescript
 import { Elysia } from 'elysia'

--- a/docs/patterns/configuration.md
+++ b/docs/patterns/configuration.md
@@ -67,7 +67,7 @@ See [TLS Options](#tls-options) for available configuration.
 Below is a config accepted by Elysia:
 
 ### prefix
-@default ``
+@default `""`
 
 Path prefix of the instance
 
@@ -218,12 +218,12 @@ If set, the HTTP server will listen on a unix socket instead of a port.
 ### hostname
 @default `0.0.0.0`
 
-What hostname should the server listen on
+Set the hostname which the server listens on
 
 ### maxRequestBodySize
 @default `1024 * 1024 * 128` (128MB)
 
-What is the maximum size of a request body? (in bytes)
+Set the maximum size of a request body (in bytes)
 
 ### reusePort
 @default `true`
@@ -276,9 +276,9 @@ Multiple keys using different algorithms can be provided either as an array of u
 
 The object form can only occur in an array.
 
-object.passphrase is optional. Encrypted keys will be decrypted with
+**object.passphrase** is optional. Encrypted keys will be decrypted with
 
-object.passphrase if provided, or options.passphrase if it is not.
+**object.passphrase** if provided, or **options.passphrase** if it is not.
 
 ### ca
 Optionally override the trusted CA certificates. Default is to trust the well-known CAs curated by Mozilla.

--- a/docs/patterns/cookie.md
+++ b/docs/patterns/cookie.md
@@ -150,7 +150,7 @@ new Elysia()
 ```
 
 ## Cookie Signature
-With an introduction of Cookie Schema, and `t.Cookie` type. We are able to create a unified type for handling sign/verify cookie signature automatically.
+With an introduction of Cookie Schema, and `t.Cookie` type, we can create a unified type for handling sign/verify cookie signature automatically.
 
 Cookie signature is a cryptographic hash appended to a cookie's value, generated using a secret key and the content of the cookie to enhance security by adding a signature to the cookie.
 
@@ -304,11 +304,11 @@ This is an attribute that has not yet been fully standardized and may change in 
 
 ### sameSite
 Specifies the boolean or string to be the value for the [SameSite Set-Cookie attribute](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-09#section-5.4.7).
-true will set the SameSite attribute to Strict for strict same-site enforcement.
-false will not set the SameSite attribute.
-'lax' will set the SameSite attribute to Lax for lax same-site enforcement.
-'none' will set the SameSite attribute to None for an explicit cross-site cookie.
-'strict' will set the SameSite attribute to Strict for strict same-site enforcement.
+`true` will set the SameSite attribute to Strict for strict same-site enforcement.
+`false` will not set the SameSite attribute.
+`'lax'` will set the SameSite attribute to Lax for lax same-site enforcement.
+`'none'` will set the SameSite attribute to None for an explicit cross-site cookie.
+`'strict'` will set the SameSite attribute to Strict for strict same-site enforcement.
 More information about the different enforcement levels can be found in [the specification](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-09#section-5.4.7).
 
 ::: tip

--- a/docs/patterns/cookie.md
+++ b/docs/patterns/cookie.md
@@ -48,7 +48,7 @@ To use Cookie attribute, you can either use one of the following:
 1. Setting the property directly
 2. Using `set` or `add` to update cookie property.
 
-See [cookie attribute config](/patterns/cookie-signature#config) for more information.
+See [cookie attribute config](/patterns/cookie.html#config) for more information.
 
 ### Assign Property
 You can get/set the property of a cookie like any normal object, the reactivity model synchronizes the cookie value automatically.

--- a/docs/patterns/trace.md
+++ b/docs/patterns/trace.md
@@ -109,7 +109,7 @@ const app = new Elysia()
 Randomly generated unique id for each request
 
 ### context - `Context`
-Elysia's [Context](/essential/context), eg. `set`, `store`, `query, `params`
+Elysia's [Context](/essential/handler.html#context), eg. `set`, `store`, `query`, `params`
 
 ### set - `Context.set`
 Shortcut for `context.set`, to set a headers or status of the context

--- a/docs/patterns/unit-test.md
+++ b/docs/patterns/unit-test.md
@@ -57,7 +57,7 @@ The request must provide URL as the following:
 | http://localhost/user | ✅    |
 | /user                 | ❌    |
 
-We can also use other testing libraries like Jest or testing library to create Elysia unit tests.
+We can also use other testing libraries like Jest to create Elysia unit tests.
 
 ## Eden Treaty test
 

--- a/docs/patterns/websocket.md
+++ b/docs/patterns/websocket.md
@@ -68,7 +68,7 @@ const app = new Elysia()
 WebSocket schema can validate the following:
 
 -   **message** - An incoming message.
--   **query** - query string or URL parameters.
+-   **query** - Query string or URL parameters.
 -   **params** - Path parameters.
 -   **header** - Request's headers.
 -   **cookie** - Request's cookie
@@ -152,8 +152,8 @@ Type:
 .ws(endpoint: path, options: Partial<WebSocketHandler<Context>>): this
 ```
 
-endpoint: A path to exposed as websocket handler
-options: Customize WebSocket handler behavior
+* **endpoint** - A path to exposed as websocket handler
+* **options** - Customize WebSocket handler behavior
 
 ## WebSocketHandler
 

--- a/docs/plugins/cors.md
+++ b/docs/plugins/cors.md
@@ -128,7 +128,6 @@ Response with **OPTIONS** request with 3 HTTP request headers:
 
 This config indicates if the server should respond to preflight requests.
 
----
 ## Pattern
 Below you can find the common patterns to use the plugin.
 

--- a/docs/plugins/cors.md
+++ b/docs/plugins/cors.md
@@ -146,4 +146,4 @@ const app = new Elysia()
     .listen(3000)
 ```
 
-This will allow requests from top-level domains with `saltyaom.com'
+This will allow requests from top-level domains with `saltyaom.com`

--- a/docs/plugins/graphql-apollo.md
+++ b/docs/plugins/graphql-apollo.md
@@ -87,11 +87,11 @@ This plugin extends Apollo's [ServerRegistration](https://www.apollographql.com/
 
 Below are the extended parameters for configuring Apollo Server with Elysia.
 ### path
-@default "/graphql"
+@default `"/graphql"`
 
 Path to expose Apollo Server.
 
 ### enablePlayground
-@default "process.env.ENV !== 'production'
+@default `process.env.ENV !== 'production'`
 
 Determine whether should Apollo should provide Apollo Playground.

--- a/docs/recipe/drizzle.md
+++ b/docs/recipe/drizzle.md
@@ -20,7 +20,7 @@ Drizzle ORM is a headless TypeScript ORM with a focus on type safety and develop
 We may convert Drizzle schema to Elysia validation models using `drizzle-typebox`
 
 ### Drizzle Typebox
-[Elysia.t](/validation/overview) is a fork of TypeBox, allowing us to use any TypeBox type in Elysia directly.
+[Elysia.t](/essential/validation.html#elysia-type) is a fork of TypeBox, allowing us to use any TypeBox type in Elysia directly.
 
 We can convert Drizzle schema into TypeBox schema using ["drizzle-typebox"](https://npmjs.org/package/drizzle-typebox), and use it directly on Elysia's schema validation.
 
@@ -377,4 +377,4 @@ The `spread` utility function will skip a refined schema, so you can use it as i
 
 ---
 
-For more information, please refer to the [Drizzle ORM](https://orm.drizzle-orm) and [Drizzle TypeBox](https://orm.drizzle.team/docs/typebox) documentation.
+For more information, please refer to the [Drizzle ORM](https://orm.drizzle.team) and [Drizzle TypeBox](https://orm.drizzle.team/docs/typebox) documentation.

--- a/docs/recipe/openapi.md
+++ b/docs/recipe/openapi.md
@@ -17,7 +17,7 @@ head:
 # OpenAPI
 Elysia has first-class support and follows OpenAPI schema by default.
 
-Elysia can automatically generate an API documentation page and by providing a Swagger plugin.
+Elysia can automatically generate an API documentation page by providing a Swagger plugin.
 
 To generate the Swagger page, install the plugin:
 ```bash
@@ -95,10 +95,10 @@ Additional external documentation for this operation.
 A unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is case-sensitive.
 
 ### deprecated
-Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is false.
+Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is `false`.
 
 ### security
-A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement ({}) can be included in the array.
+A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array.
 
 ## Hide
 You can hide the route from the Swagger page by setting `detail.hide` to `true`

--- a/docs/recipe/opentelemetry.md
+++ b/docs/recipe/opentelemetry.md
@@ -109,7 +109,7 @@ Elysia OpenTelemetry will group lifecycle and read the **function name** of each
 
 It's a good time to **name your function**.
 
-If your hook handler is an arrow function, you may refactor it to named function to understand the trace better otherwise, your trace span will be named as `anonymous`.
+If your hook handler is an arrow function, you may refactor it to named function to understand the trace better, otherwise your trace span will be named as `anonymous`.
 
 ```typescript
 const bad = new Elysia()


### PR DESCRIPTION
This PR is a continuation for https://github.com/elysiajs/documentation/pull/459

- [fix typos and formatting on pages from Patterns to Integration](https://github.com/elysiajs/documentation/commit/ee84674b1fefd4525d8a423c90e378a06ae7a6f7)

- [fix break links from `Patterns` to `Integration` (and `Cheat Seet`)](https://github.com/elysiajs/documentation/commit/7eed06bd0033a2800469f8cf8be41e6cda3052e9)

- [remove an unnecessary section divider](https://github.com/elysiajs/documentation/commit/f09f6aeaa87897551e063916eb946b5c3a94fc74)