### PR TITLE
Fix some development warnings

### DIFF
--- a/components/blog/Landing.vue
+++ b/components/blog/Landing.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script lang="ts" setup>
-import { defineProps } from 'vue'
 
 import Ray from '../../components/midori/ray.vue'
 

--- a/components/blog/Layout.vue
+++ b/components/blog/Layout.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts" setup>
-import { defineProps, onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 
 import '../tailwind.css'
 

--- a/components/nearl/card.vue
+++ b/components/nearl/card.vue
@@ -9,7 +9,6 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue'
 
 const props = defineProps<{
     href: string

--- a/components/nearl/playground.vue
+++ b/components/nearl/playground.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import type { Elysia } from 'elysia'
 
 const { elysia, mock = {}, alias = {} } = defineProps<{

--- a/docs/essential/validation.md
+++ b/docs/essential/validation.md
@@ -560,6 +560,7 @@ TypeBox provides a basic primitive type with the same behavior as same as TypeSc
 The following table lists the most common basic type:
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>TypeBox</td>
 <td>TypeScript</td>
@@ -689,7 +690,7 @@ t.Literal(42)
 
 </td>
 </tr>
-
+</tbody>
 </table>
 
 Elysia extends all types from TypeBox allowing you to reference most of the API from TypeBox to use in Elysia.
@@ -701,6 +702,7 @@ See [TypeBox's Type](https://github.com/sinclairzx81/typebox#json-types) for add
 TypeBox can accept an argument for more comprehensive behavior based on JSON Schema 7 specification.
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>TypeBox</td>
 <td>TypeScript</td>
@@ -804,7 +806,7 @@ y: 200
 
 </td>
 </tr>
-
+</tbody>
 </table>
 
 See [JSON Schema 7 specification](https://json-schema.org/draft/2020-12/json-schema-validation) For more explanation for each attribute.
@@ -818,6 +820,7 @@ The following are common patterns that are often found useful when creating a sc
 Allow multiple types via union.
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>TypeBox</td>
 <td>TypeScript</td>
@@ -852,7 +855,7 @@ Hello
 
 </td>
 </tr>
-
+</tbody>
 </table>
 
 ### Optional
@@ -860,6 +863,7 @@ Hello
 Provided in a property of `t.Object`, allowing the field to be undefined or optional.
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>TypeBox</td>
 <td>TypeScript</td>
@@ -898,7 +902,7 @@ t.Object({
 
 </td>
 </tr>
-
+</tbody>
 </table>
 
 ### Partial
@@ -906,6 +910,7 @@ t.Object({
 Allowing all of the fields in `t.Object` to be optional.
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>TypeBox</td>
 <td>TypeScript</td>
@@ -946,7 +951,7 @@ t.Partial(
 
 </td>
 </tr>
-
+</tbody>
 </table>
 
 ## Custom Error
@@ -954,6 +959,7 @@ t.Partial(
 TypeBox offers an additional "**error**" property, allowing us to return a custom error message if the field is invalid.
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>TypeBox</td>
 <td>Error</td>
@@ -999,7 +1005,7 @@ Invalid object UwU
 
 </td>
 </tr>
-
+</tbody>
 </table>
 
 ## Elysia Type
@@ -1176,6 +1182,7 @@ new Elysia()
 The following is an example of usage of the error property on various types:
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>TypeBox</td>
 <td>Error</td>
@@ -1265,7 +1272,7 @@ Expected x to be a number
 
 </td>
 </tr>
-
+</tbody>
 </table>
 
 ### Error message as function
@@ -1299,6 +1306,7 @@ Please be cautious that the error function will only be called if the field is i
 Please consider the following table:
 
 <table class="md-table">
+<tbody>
 <tr>
 <td>Code</td>
 <td>Body</td>
@@ -1390,7 +1398,7 @@ t.Object(
 Expected value to be an object
 </td>
 </tr>
-
+</tbody>
 </table>
 
 ### onError

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,9 @@
     "allowJs": true,
     "strict": true,
     "jsx": "preserve"
-  }
+  },
+  "exclude": [
+    "postcss.config.js",
+    "tailwind.config.js"
+  ]
 }


### PR DESCRIPTION
This PR fixes a couple of warnings when running the website.
I'm not fluent in Vue, but it seems to be running well.

- The [first commit](https://github.com/elysiajs/documentation/pull/462/commits/efc7cc4827fc560295820bbd1558aba2fd0ffd89) fixes this warning when building:

> [@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported"

The fix is just removing all the `defineProps` imports.

- The [second commit](https://github.com/elysiajs/documentation/pull/462/commits/26feb6d4d09e611159af644fbc3de3b2652c21cf) fixes this warning when rendering the `/essential/validation.html` page:

> `<tr>` cannot be child of `<table>`

The fix is wrapping the `<table>` children with `<tbody>`. It seems that we already do it when building for production, but we need to explicitly write to do it in development mode too to suppress this warning.

The warning message is misleading btw (see https://github.com/vuejs/core/issues/12088)

- The [third commit](https://github.com/elysiajs/documentation/pull/462/commits/3f231fae687b2b13ece28433643a91e42e2b6b09) fixes this warning from `tsconfig.json`:

> Cannot write file '/Users/macabeus/elysiajs/documentation/postcss.config.js' because it would overwrite input file.ts
> Cannot write file '/Users/macabeus/elysiajs/documentation/tailwind.config.js' because it would overwrite input file.ts

The fix is including these files in the `exclude` property from `tsconfig.json`.