### PR TITLE
fix: fix diff

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -421,8 +421,8 @@ const app = new Elysia()
     .use(note) // [!code ++]
     .decorate('note', new Note()) // [!code --]
     .get('/note', ({ note }) => note.data) // [!code --]
-    .get(
-        '/note/:index',
+    .get( // [!code --]
+        '/note/:index', // [!code --]
         ({ note, params: { index }, error }) => { // [!code --]
             return note.data[index] ?? error(404, 'oh no :(') // [!code --]
         },

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -425,12 +425,12 @@ const app = new Elysia()
         '/note/:index', // [!code --]
         ({ note, params: { index }, error }) => { // [!code --]
             return note.data[index] ?? error(404, 'oh no :(') // [!code --]
-        },
+        }, // [!code --]
         { // [!code --]
             params: t.Object({ // [!code --]
                 index: t.Number() // [!code --]
             }) // [!code --]
-        }
+        } // [!code --]
     ) // [!code --]
     .listen(3000)
 ```


### PR DESCRIPTION
Previously, it would not highlight the code that was removed.
before: 
![image](https://github.com/user-attachments/assets/815190db-1073-4707-ae15-5eeb2036b7e6)
after:
![image](https://github.com/user-attachments/assets/5868ff75-15f8-4d3e-9ff6-5c060bbb79d6)
