### PR TITLE
Fixing Quick Start Node install instructions & Warning if not using TypeScript

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -147,7 +147,7 @@ If you are using TypeScript, make sure to create, and update `tsconfig.json` to 
 
 Node.js is a JavaScript runtime for server-side applications, the most popular runtime for JavaScript which Elysia supports.
 
-You can install Bun with the command below:
+You can install Node.js with the command below:
 
 ::: code-group
 
@@ -259,7 +259,7 @@ Don't forget to update `tsconfig.json` to include `compilerOptions.strict` to `t
 <template v-slot:js>
 
 ::: warning
-Using Elysia with TypeScript will miss out on some features auto-completion, advanced type checking and end-to-end type safety which is the core feature of Elysia.
+If you use Elysia without TypeScript you may miss out on some features like auto-completion, advanced type checking and end-to-end type safety, which are the core features of Elysia.
 :::
 
 To create a new Elysia app with JavaScript, starts by installing Elysia:


### PR DESCRIPTION
When you select the tab for installing Elysia for Node in the quick start guide, the first instruction to install Node accidentally has the following text:

> You can install Bun with the command below:

This replaces the reference to "Bun" with "Node.js", to be consistent with the code snippet below installing Node.js with Brew.

```diff
- You can install Bun with the command below:
+ You can install Node.js with the command below:
```

In addition, the next section has two different tabs, one for TS and one for JS. If you select the JS one, it warns you:

> Using Elysia with TypeScript will miss out on some features auto-completion, advanced type checking and end-to-end type safety which is the core feature of Elysia.

_(before)_

I think the "with" was meant to be "without", but then I tweaked the wording a bit more, thinking about how JSDoc types might be a workaround to use JS with Elysia and still get most of those features.

> If you use Elysia without TypeScript you may miss out on some features like auto-completion, advanced type checking and end-to-end type safety, which are the core features of Elysia.

_(after)_
