### PR TITLE
Fix route documentation demo order & lifecycle throw demo comment

### DIFF
--- a/docs/essential/life-cycle.md
+++ b/docs/essential/life-cycle.md
@@ -25,13 +25,13 @@ const demo = new Elysia()
 	.onError(({ code }) => {
 		if (code === 418) return 'caught'
 	})
+    .get('/throw', ({ error }) => {
+		// This will be caught by onError
+		throw error(418)
+	})
 	.get('/return', ({ error }) => {
 		// This will NOT be caught by onError
 		return error(418)
-	})
-	.get('/throw', ({ error }) => {
-		// This will NOT be caught by onError
-		throw error(418)
 	})
 </script>
 
@@ -781,7 +781,7 @@ new Elysia()
         if (code === 418) return 'caught'
     })
     .get('/throw', ({ error }) => {
-        // This will NOT be caught by onError
+        // This will be caught by onError
         throw error(418)
     })
     .get('/return', () => {

--- a/docs/essential/route.md
+++ b/docs/essential/route.md
@@ -27,9 +27,8 @@ const demo2 = new Elysia()
     .post('/hi', () => 'hi')
 
 const demo3 = new Elysia()
-    .get('/get', () => 'hello')
-    .post('/post', () => 'hi')
-    .route('M-SEARCH', '/m-search', () => 'connect')
+	  .get('/id', () => `id: undefined`)
+    .get('/id/:id', ({ params: { id } }) => `id: ${id}`)
 
 const demo4 = new Elysia()
     .get('/', () => 'hi')
@@ -54,8 +53,9 @@ const demo7 = new Elysia()
     .get('/id/:id/:name', ({ params: { id, name } }) => id + ' ' + name)
 
 const demo8 = new Elysia()
-	.get('/id', () => `id: undefined`)
-    .get('/id/:id', ({ params: { id } }) => `id: ${id}`)
+    .get('/get', () => 'hello')
+    .post('/post', () => 'hi')
+    .route('M-SEARCH', '/m-search', () => 'connect')
 
 const demo9 = new Elysia()
     .get('/id/:id', ({ params: { id } }) => id)


### PR DESCRIPTION
Found a few areas of improvement while reading the docs:

1. The `/essential/route.html#optional-path-parameters` demo needed to be swapped with the `/essential/route.html#custom-method` as they were mismatched
2. The comment on the `/essential/life-cycle.html#to-throw-or-to-return` code snippet incorrectly stated that the throw example would not be caught by the `onError` handler
3. Also changed the default route on the `/essential/life-cycle.html#to-throw-or-to-return` to show the throw handler first to match the order in which the docs presents the error handling scenarios

Thanks!