### PR TITLE
fix: `npx tsc init` to `npx tsc --init`

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -242,7 +242,7 @@ These scripts refer to the different stages of developing an application:
 Make sure to create `tsconfig.json`
 
 ```bash
-npx tsc init
+npx tsc --init
 ```
 
 Don't forget to update `tsconfig.json` to include `compilerOptions.strict` to `true`:
@@ -319,7 +319,7 @@ These scripts refer to the different stages of developing an application:
 Make sure to create `tsconfig.json`
 
 ```bash
-npx tsc init
+npx tsc --init
 ```
 
 Don't forget to update `tsconfig.json` to include `compilerOptions.strict` to `true`:


### PR DESCRIPTION
Issue Encountered:
While attempting to create a `tsconfig.json` file with `npx tsc init`, I encountered the following error:
`Could not resolve the path 'init'...`

Solution:
After a quick search, I discovered that changing `init` to `--init` resolved the issue successfully, allowing me to create the `tsconfig.json` file without further problems.

If there is any misunderstanding on my side, please disregard the edit.

