### PR TITLE
fix: Typo for pattern regex param

### DIFF
--- a/docs/essential/handler.md
+++ b/docs/essential/handler.md
@@ -632,7 +632,7 @@ new Elysia()
 	.guard({
 		headers: t.Object({
 			bearer: t.String({
-				pattern: '/^Bearer .+$/'
+				pattern: '^Bearer .+$'
 			})
 		})
 	})


### PR DESCRIPTION
The `pattern` option of `t.String` must be the string contents of a RegEx, excluding the `/` delimiters. I tripped up on this when trying to follow this example and hoping to spare others the same footgun.