### PR TITLE
docs(tutorial): fix sign-in and sign-up typos

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -863,8 +863,8 @@ Now there are a lot of things to unwrap here:
 2. In the instance, we define an in-memory store `user` and `session`
 	- 2.1 `user` will hold key-value of `username` and `password`
 	- 2.2 `session` will hold a key-value of `session` and `username`
-3. In `/sign-in` we insert a username and hashed password with argon2id
-4. In `/sign-up` we do the following:
+3. In `/sign-up` we insert a username and hashed password with argon2id
+4. In `/sign-in` we do the following:
 	- 4.1 We check if user exists and verify the password
 	- 4.2 If the password matches, then we generate a new session into `session`
 	- 4.3 We set cookie `token` with the value of session


### PR DESCRIPTION
The `sign-up` and `sign-in` has been written backwards.