### PR TITLE
fix typo: change method from POST to PUT in overview API call

### DIFF
--- a/docs/eden/overview.md
+++ b/docs/eden/overview.md
@@ -103,7 +103,7 @@ app.
 // Call [GET] at '/'
 const { data } = await app.index.get()
 
-// Call [POST] at '/nendoroid/:id'
+// Call [PUT] at '/nendoroid/:id'
 const { data: nendoroid, error } = await app.nendoroid({ id: 1895 }).put({
     name: 'Skadi',
     from: 'Arknights'


### PR DESCRIPTION
This pull request addresses a typo in the API call for the '/nendoroid/:id' endpoint in the overview example. 
The method was incorrectly labeled as `POST`, while it should be `PUT`.


<img width="724" alt="image" src="https://github.com/user-attachments/assets/e50d54cf-bbb2-4b07-ae86-0c708cc93678" />
