### PR TITLE
fix: Discord link

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -416,4 +416,4 @@ We recommend checking out the either one of the following:
     </Card>
 </Deck>
 
-If you have any questions, feel free to ask in our [Discord](https://discord.gg/elysia) community.
+If you have any questions, feel free to ask in our [Discord](https://discord.gg/eaFJ2KDJck) community.


### PR DESCRIPTION
The current link takes you to a Roblox community 💀