### PR TITLE
docs: Replace broken link to reference-model

### DIFF
--- a/docs/essential/structure.md
+++ b/docs/essential/structure.md
@@ -329,7 +329,7 @@ export const AuthModel = {
 ```
 
 ### Model Injection
-Though this is optional, if you are strictly following MVC pattern, you may want to inject like a service into a controller. We recommended using [Elysia reference model](/validation/reference-model.html#reference-model)
+Though this is optional, if you are strictly following MVC pattern, you may want to inject like a service into a controller. We recommended using [Elysia reference model](/essential/validation.html#reference-model)
 
 Using Elysia's model reference
 ```typescript twoslash


### PR DESCRIPTION
Hi, good morning! This PR replaces [this broken link](https://elysiajs.com/validation/reference-model.html#reference-model) with [this working one](https://elysiajs.com/essential/validation.html#reference-model)

This link was similarly replaced elsewhere in the documentation in commit 2d484734355ec468559b3a8b43fb58c0670fa37f

Fixes #424