### PR TITLE
Fix script for adding `devDependencies` on `pnpm` and `yarn`

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -192,7 +192,7 @@ bun add -d tsx @types/node typescript
 
 ```bash [pnpm]
 pnpm add elysia @elysiajs/node && \
-pnpm add -d tsx @types/node typescript
+pnpm add -D tsx @types/node typescript
 ```
 
 ```bash [npm]
@@ -202,7 +202,7 @@ npm install --save-dev tsx @types/node typescript
 
 ```bash [yarn]
 yarn add elysia && \
-yarn add -d tsx @types/node typescript
+yarn add -D tsx @types/node typescript
 ```
 
 :::

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -201,7 +201,7 @@ npm install --save-dev tsx @types/node typescript
 ```
 
 ```bash [yarn]
-yarn add elysia && \
+yarn add elysia @elysiajs/node && \
 yarn add -D tsx @types/node typescript
 ```
 


### PR DESCRIPTION
In `yarn` and `pnpm`, adding `devDependencies` require using `-D` instead of `-d`.  

Using lowercase `-d` will cause `yarn` unable to handle with `Unknown Syntax Error` (supporting log provided below):  
```
PS C:\Users\alex4386\git\***> yarn add -d tsx @types/node typescript
Unknown Syntax Error: Unsupported option name ("-d").

$ yarn add [--json] [-F,--fixed] [-E,--exact] [-T,--tilde] [-C,--caret] [-D,--dev] [-P,--peer] [-O,--optional] [--prefer-dev] [-i,--interactive] [--cached] [--mode #0] ...
```  

This PR fixes the documentation's command snippet by using `-D` instead of `-d`.
