### PR TITLE
fix(docs): Remove meaningless text from Elysia documentation

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1087,9 +1087,7 @@ For **1.** instead of using guard, we could use a **macro**.
 ## Plugin deduplication
 
 As we are going to reuse this hook in multiple modules (user, and note), let's extract the service (utility) part out and apply it to both modules.
-// @errors: 2538
-// @filename: user.ts
-import { Elysia, t } from 'elysia'
+
 ```ts twoslash [user.ts]
 // @errors: 2538
 import { Elysia, t } from 'elysia'
@@ -1200,9 +1198,7 @@ export const userService = new Elysia({ name: 'user/service' })
 We have just created a new macro name `isSignIn` that accepts a `boolean` value, if it is true, then we add an `onBeforeHandle` event that executes **after validation but before the main handler**, allowing us to extract authentication logic here.
 
 To use the macro, simply specify `isSignIn: true` as follows:
-// @errors: 2538
-// @filename: user.ts
-import { Elysia, t } from 'elysia'
+
 ```ts twoslash [user.ts]
 // @errors: 2538
 import { Elysia, t } from 'elysia'
@@ -1341,9 +1337,6 @@ Unlike `decorate` and `store`, resolve is defined at the `beforeHandle` stage or
 
 This ensures that the property like `cookie: 'session'` exists before creating a new property.
 
-// @errors: 2538
-// @filename: user.ts
-import { Elysia, t } from 'elysia'
 ```ts twoslash [user.ts]
 // @errors: 2538
 import { Elysia, t } from 'elysia'
@@ -1563,9 +1556,6 @@ export const user = new Elysia({ prefix: '/user' })
 
 Alternatively, if we have multiple `scoped` defined, we could use `as` to cast multiple life-cycles instead.
 
-// @errors: 2538
-// @filename: user.ts
-import { Elysia, t } from 'elysia'
 ```ts twoslash [user.ts]
 // @errors: 2538
 import { Elysia, t } from 'elysia'


### PR DESCRIPTION
This PR removes meaningless text from the documentation, such as:
/l @errors: 2538 // @filename: user.ts import { Elysia, t } from 'elysia'.

Screenshots of the before and after are attached for reference.

Before:
1
<img width="723" alt="Captura de pantalla 2025-03-02 a la(s) 20 03 17" src="https://github.com/user-attachments/assets/670cd850-371e-4d1f-bf25-fcab453c7176" />
2
<img width="758" alt="Captura de pantalla 2025-03-02 a la(s) 20 03 32" src="https://github.com/user-attachments/assets/54542232-aa45-4f55-9058-cfa50263e1bc" />
3
<img width="760" alt="Captura de pantalla 2025-03-02 a la(s) 20 03 53" src="https://github.com/user-attachments/assets/4fbca1e9-538f-433c-8384-9ce963b616c6" />
4
<img width="757" alt="Captura de pantalla 2025-03-02 a la(s) 20 21 00" src="https://github.com/user-attachments/assets/a27156d5-2eac-47a7-aa1d-bd9a812337cb" />


After:
1
<img width="771" alt="Captura de pantalla 2025-03-02 a la(s) 20 13 07" src="https://github.com/user-attachments/assets/2645bff9-b4e5-41aa-8e30-7bbab3d2fc42" />
2
<img width="770" alt="Captura de pantalla 2025-03-02 a la(s) 20 13 43" src="https://github.com/user-attachments/assets/907f49d4-83fb-4a49-ab0b-658d4b9a7a4f" />
3
<img width="754" alt="Captura de pantalla 2025-03-02 a la(s) 20 14 21" src="https://github.com/user-attachments/assets/2313f82f-f8a2-4aec-8fe6-9a24a349c7b9" />
4
<img width="749" alt="Captura de pantalla 2025-03-02 a la(s) 20 20 53" src="https://github.com/user-attachments/assets/b87b6518-a65d-4f1d-a263-4418c607324c" />

