### PR TITLE
📝doc: Fix syntax error in api.ts example Integration with Nuxt

### DIFF
--- a/docs/integrations/nuxt.md
+++ b/docs/integrations/nuxt.md
@@ -39,7 +39,7 @@ export default defineNuxtConfig({
 
 ```typescript [api.ts]
 export default () => new Elysia() // [!code ++]
-  .get('/hello', () => ({ message: 'Hello world!' }) // [!code ++]
+  .get('/hello', () => ({ message: 'Hello world!' })) // [!code ++]
 ```
 
 4. Use Eden Treaty in your Nuxt app:


### PR DESCRIPTION
fix syntax error in api.ts example of Integration with Nuxt