### PR TITLE
fix: wrong life cycle example

### DIFF
--- a/docs/essential/life-cycle.md
+++ b/docs/essential/life-cycle.md
@@ -195,7 +195,7 @@ Console should log the following:
 1
 ```
 
-Notice that it doesn't log **3**, because the event is registered after the route so it is not applied to the route.
+Notice that it doesn't log **2**, because the event is registered after the route so it is not applied to the route.
 
 This also applies to the plugin.
 


### PR DESCRIPTION
I was reading your **awesome** documentation and found out this small error. The example above uses `console.log("1")` and `console.log("2")` but the text says `3`.