### PR TITLE
chore: Added missing trpc import in example

### DIFF
--- a/docs/blog/integrate-trpc-with-elysia.md
+++ b/docs/blog/integrate-trpc-with-elysia.md
@@ -152,7 +152,7 @@ And in the Elysia server
 ```typescript
 import { Elysia } from 'elysia'
 import { cors } from '@elysiajs/cors'
-import '@elysiajs/trpc'
+import { trpc } '@elysiajs/trpc'
 
 import { router, createContext } from './trpc' // [!code ++]
 


### PR DESCRIPTION
I was just trying to run the example and had the type error, thought I'd submit the fix upstream as well.