### PR TITLE
docs: fix unintended code block level in TRPC page

### DIFF
--- a/docs/plugins/trpc.md
+++ b/docs/plugins/trpc.md
@@ -53,7 +53,7 @@ const app = new Elysia().use(trpc(router)).listen(3000)
 
 Accept the tRPC router and register to Elysia's handler.
 
-````ts
+```typescript
 trpc(
 	router: Router,
 	option?: {
@@ -67,4 +67,3 @@ trpc(
 ### endpoint
 
 The path to the exposed TRPC endpoint.
-````


### PR DESCRIPTION
The code block in the docs appear to cover too much information, also including the markdown heading. This PR aims to fix this by fixing the range of the code block in the documentation.

<img width="828" alt="image" src="https://github.com/user-attachments/assets/87ad6d44-0784-4db4-bff7-5535a1512832" />
