### PR TITLE
docs: Replace should with expect in best-practice.md

### DIFF
--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -230,7 +230,7 @@ You can test your controller using `handle` to directly call a function (and it'
 import { Elysia } from 'elysia'
 import { Service } from './service'
 
-import { describe, it, should } from 'bun:test'
+import { describe, it, expect } from 'bun:test'
 
 const app = new Elysia()
     .get('/', ({ stuff }) => {


### PR DESCRIPTION
I know it's a silly thing but there's no `should` export in bun:test, the correct import should be `expect`. 