### PR TITLE
docs(fix): AuthModel import

### DIFF
--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -83,7 +83,7 @@ export const auth = new Elysia({ prefix: '/auth' })
 // Service handle business logic, decoupled from Elysia controller
 import { status } from 'elysia'
 
-import type { AuthModel } from './service'
+import type { AuthModel } from './model'
 
 // If the class doesn't need to store a property,
 // you may use `abstract class` to avoid class allocation


### PR DESCRIPTION
Just a quick fix to the `AuthModel` import path in `best-practice.md`. It was pointing to `./service`, but it should be` ./model`.