### PR TITLE
docs: :memo: remove typo doesn't not

### DIFF
--- a/docs/migrate/from-express.md
+++ b/docs/migrate/from-express.md
@@ -486,7 +486,7 @@ While Hono has a `next` function to call the next middleware, Elysia does not ha
 ## Sounds type safety
 Elysia is designed to be sounds type safety.
 
-For example, you can customize context in a **type safe** manner using [derive](/essential/life-cycle.html#derive) and [resolve](/essential/life-cycle.html#resolve) while Express doesn't not.
+For example, you can customize context in a **type safe** manner using [derive](/essential/life-cycle.html#derive) and [resolve](/essential/life-cycle.html#resolve) while Express doesn't.
 
 <Compare>
 

--- a/docs/migrate/from-fastify.md
+++ b/docs/migrate/from-fastify.md
@@ -550,7 +550,7 @@ const app = new Elysia()
 ## Sounds type safety
 Elysia is designed to be sounds type safety.
 
-For example, you can customize context in a **type safe** manner using [derive](/essential/life-cycle.html#derive) and [resolve](/essential/life-cycle.html#resolve) while Fastify doesn't not.
+For example, you can customize context in a **type safe** manner using [derive](/essential/life-cycle.html#derive) and [resolve](/essential/life-cycle.html#resolve) while Fastify doesn't.
 
 <Compare>
 

--- a/docs/migrate/from-hono.md
+++ b/docs/migrate/from-hono.md
@@ -501,7 +501,7 @@ While Hono has a `next` function to call the next middleware, Elysia does not ha
 ## Sounds type safety
 Elysia is designed to be sounds type safety.
 
-For example, you can customize context in a **type safe** manner using [derive](/essential/life-cycle.html#derive) and [resolve](/essential/life-cycle.html#resolve) while Hono doesn't not.
+For example, you can customize context in a **type safe** manner using [derive](/essential/life-cycle.html#derive) and [resolve](/essential/life-cycle.html#resolve) while Hono doesn't.
 
 <Compare>
 


### PR DESCRIPTION
I found typo "doesn't not" in migration tutorial on all 3 examples.