### PR TITLE
Clarify Service Locator pattern

### DIFF
--- a/docs/essential/plugin.md
+++ b/docs/essential/plugin.md
@@ -307,11 +307,14 @@ const setup = new Elysia({ name: 'setup' })
 const error = new Elysia()
     .get('/', ({ a }) => a)
 
-const main = new Elysia()
-	// With `setup`, type will be inferred
+// With `setup`, type will be inferred
+const child = new Elysia()
     .use(setup) // [!code ++]
     .get('/', ({ a }) => a)
     //           ^?
+
+const main = new Elysia()
+    .use(child)
 ```
 
 <Playground :elysia="demo5" />

--- a/docs/key-concept.md
+++ b/docs/key-concept.md
@@ -208,11 +208,14 @@ const setup = new Elysia({ name: 'setup' })
 const error = new Elysia()
     .get('/', ({ a }) => a)
 
-const main = new Elysia()
-	// With `setup`, type will be inferred
+// With `setup`, type will be inferred
+const child = new Elysia()
     .use(setup) // [!code ++]
     .get('/', ({ a }) => a)
     //           ^?
+
+const main = new Elysia()
+    .use(child)
 ```
 
 As mentioned in [dependencies](#dependencies), we can use the `name` property to deduplicate the instance so it will not have any performance penalty or lifecycle duplication.


### PR DESCRIPTION
Likely resolves #585.

Current explanation about the Service Locator pattern in `Getting Started` and `Essential > Plugins` is a bit confusing, because the *correct* example has a different layout than the *wrong* example: (current)

<img width="721" height="957" alt="image" src="https://github.com/user-attachments/assets/163c9916-1b24-4cbe-b44a-05fd88ab4912" />

This PR attempts to make it more easily understandable by providing the *correct* example a better parallel with the *wrong* example:

<img width="726" height="1128" alt="image" src="https://github.com/user-attachments/assets/91f4a658-6df8-4d61-9cb9-bdda4840bfc6" />

Please let me know if this is not what was intended by the docs!