### PR TITLE
Fix typo in error-handling documentation

### DIFF
--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -252,7 +252,7 @@ new Elysia()
 ```
 
 ### Custom Error Response
-You can also provide a custom `toResposne` method in your custom error class to return a custom response when the error is thrown.
+You can also provide a custom `toResponse` method in your custom error class to return a custom response when the error is thrown.
 
 ```typescript
 import { Elysia } from 'elysia'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the Custom Error Response section: the method name is now shown as “toResponse” (previously misspelled). This aligns the docs with the actual API and improves clarity, reducing potential copy-paste mistakes when implementing error handling. No behavioral or API changes—this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->