### PR TITLE
fix: update tinny typo

### DIFF
--- a/docs/patterns/openapi.md
+++ b/docs/patterns/openapi.md
@@ -43,7 +43,7 @@ For OpenAPI plugin configuration, see the [OpenAPI plugin page](/plugins/openapi
 
 We can add route information by providing a schema type.
 
-However, sometimes defining only a type does not make it clear what the route might do. You can use [deetail](/plugins/openapi#detail) fields to explicitly describe the route.
+However, sometimes defining only a type does not make it clear what the route might do. You can use [detail](/plugins/openapi#detail) fields to explicitly describe the route.
 
 ```typescript
 import { Elysia, t } from 'elysia'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the OpenAPI patterns guide, correcting a broken anchor link in the “Describing route” section.
  * Improved navigation by ensuring the “detail” anchor points to the correct section.
  * Clarified wording to enhance readability and reduce confusion for readers.
  * No changes to application functionality or APIs; this update affects documentation only.
  * Users should now experience accurate in-page linking when referencing the detailed route description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->