### PR TITLE
Fix openapi.md `/swagger/json` link

### DIFF
--- a/docs/plugins/openapi.md
+++ b/docs/plugins/openapi.md
@@ -37,7 +37,7 @@ new Elysia()
     .listen(3000)
 ```
 
-Accessing `/openapi` would show you a Scalar UI with the generated endpoint documentation from the Elysia server. You can also access the raw OpenAPI spec at `/swagger/json`.
+Accessing `/openapi` would show you a Scalar UI with the generated endpoint documentation from the Elysia server. You can also access the raw OpenAPI spec at `/openapi/json`.
 
 ::: tip
 This page is the plugin configuration reference.


### PR DESCRIPTION
> Accessing /openapi would show you a Scalar UI with the generated endpoint documentation from the Elysia server. You can also access the raw OpenAPI spec at /swagger/json.

Upon downloading `@elysiajs/openapi` and visiting `/swagger/json` I got a NOT FOUND. Then I read about https://elysiajs.com/plugins/openapi.html#specpath. Seems like what we actually want in there in the docs is `/openapi/json` and not `/swagger/json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenAPI spec endpoint example from /swagger/json to /openapi/json to reflect current conventions.
  * Clarified guidance to help users reference the correct endpoint in their tooling and scripts.
  * No functional changes to the product; only examples and wording were adjusted. Users relying on the previous example should update references to /openapi/json.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->