### PR TITLE
Update vercel.md

### DIFF
--- a/docs/integrations/vercel.md
+++ b/docs/integrations/vercel.md
@@ -45,6 +45,7 @@ export default new Elysia()
 ```json
 {
     "$schema": "https://openapi.vercel.sh/vercel.json",
+	"builds": [{ "src": "api/**/*.ts", "use": "@vercel/node" }],
     "rewrites": [
 		{
 			"source": "/(.*)",


### PR DESCRIPTION
Without this, Vercel won't deploy it correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Vercel integration guide to include a builds configuration for TypeScript API routes using the Node builder, with guidance on where to place it in vercel.json. The existing rewrites example remains unchanged. This makes the example copy‑pasteable, clarifies required setup for deploying serverless functions on Vercel, and reduces configuration confusion. No product behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->