### PR TITLE
Fix import in sample code of `integrations/cloudflare-worker`

### DIFF
--- a/docs/integrations/cloudflare-worker.md
+++ b/docs/integrations/cloudflare-worker.md
@@ -27,7 +27,7 @@ wrangler init elysia-on-cloudflare
 2. Then add Cloudflare Adapter to your Elysia app, and make sure you called `.compile()` before exporting the app.
 ```ts
 import { Elysia } from 'elysia'
-import { CloudflareAdapter } from 'elysia/adapter/cloudflare' // [!code ++]
+import { CloudflareAdapter } from 'elysia/adapter/cloudflare-worker' // [!code ++]
 
 export default new Elysia({
 	adapter: CloudflareAdapter // [!code ++]
@@ -127,7 +127,7 @@ As of Elysia 1.4.7, you can now use Ahead of Time Compilation with Cloudflare Wo
 
 ```ts
 import { Elysia } from 'elysia'
-import { CloudflareAdapter } from 'elysia/adapter/cloudflare' // [!code ++]
+import { CloudflareAdapter } from 'elysia/adapter/cloudflare-worker' // [!code ++]
 
 export default new Elysia({
 	aot: false, // [!code --]


### PR DESCRIPTION
I just tried out the Cloudflare Workers adapter, and it seems the import file name should be `cloudflare-worker`, not `cloudflare`. :sweat:

ref: https://github.com/elysiajs/elysia/blob/eb4d126d5d0845cdcf4d3cb52dd949f2507eaf92/package.json#L131