### PR TITLE
Update tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -48,13 +48,13 @@ If you have used other popular frameworks like Express, Fastify, or Hono, you wi
 
 <Deck>
 	<Card title="From Express" href="/migrate/from-express">
-		Comparison between tRPC and Elysia
+		Comparison between Express and Elysia
 	</Card>
     <Card title="From Fastify" href="/migrate/from-fastify">
   		Comparison between Fastify and Elysia
     </Card>
     <Card title="From Hono" href="/migrate/from-hono">
-  		Comparison between tRPC and Elysia
+  		Comparison between Hono and Elysia
     </Card>
     <Card title="From tRPC" href="/migrate/from-trpc">
   		Comparison between tRPC and Elysia


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial cards to accurately describe comparisons.
    - “From Express” now says “Comparison between Express and Elysia.”
    - “From Hono” now says “Comparison between Hono and Elysia.”
  * Improves clarity for readers evaluating or migrating from Express or Hono to Elysia, reducing confusion with previous tRPC wording.
  * Text-only updates; no functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->