### PR TITLE
small typo in structure.md

### DIFF
--- a/docs/essential/structure.md
+++ b/docs/essential/structure.md
@@ -162,7 +162,7 @@ As Elysia type is complex, and heavily depends on plugin and multiple level of c
 
 We recommend abstracting service classes away from Elysia.
 
-However, **if the service is a request dependent service** or needs to process HTTP requests, ee recommend abstracting it as an Elysia instance to ensure type integrity and inference:
+However, **if the service is a request dependent service** or needs to process HTTP requests, we recommend abstracting it as an Elysia instance to ensure type integrity and inference:
 
 ```typescript
 import { Elysia } from 'elysia'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the Guidance section under “Request Dependent Service,” changing “ee recommend” to “we recommend” for improved clarity and professionalism.
  * Enhances readability and consistency of the documentation.
  * No changes to application behavior, configuration, or APIs.
  * No impact on error handling, control flow, or semantics; purely a textual correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->