### PR TITLE
Fix valibot import in hono migration docs

### DIFF
--- a/docs/migrate/from-hono.md
+++ b/docs/migrate/from-hono.md
@@ -342,7 +342,7 @@ const app = new Elysia()
 
 ```ts twoslash [Elysia Valibot]
 import { Elysia } from 'elysia'
-import * as v from 'zod'
+import * as v from 'valibot'
 
 const app = new Elysia()
 	.patch('/user/:id', ({ params, body }) => ({


### PR DESCRIPTION
This pull request updates the hono migration documentation to correctly import from valibot instead of zod in the valibot example.

Documentation update:

* In `docs/migrate/from-hono.md`, replaced the import of `zod` with `valibot` in the code example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide to replace the validation library in the Elysia example from Zod to Valibot, aligning the import and example usage with Valibot.
  * Ensured the sample code reflects correct Valibot semantics for consistency.
  * No functional changes to the product; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->