### PR TITLE
Fix ai-sdk.md examples with undefined 'result' object

### DIFF
--- a/docs/integrations/ai-sdk.md
+++ b/docs/integrations/ai-sdk.md
@@ -35,10 +35,10 @@ new Elysia().get('/', () => {
     })
 
     // Just return a ReadableStream
-    return result.textStream // [!code ++]
+    return stream.textStream // [!code ++]
 
     // UI Message Stream is also supported
-    return result.toUIMessageStream() // [!code ++]
+    return stream.toUIMessageStream() // [!code ++]
 })
 ```
 
@@ -61,10 +61,10 @@ new Elysia().get('/', () => {
     })
 
     // Each chunk will be sent as a Server Sent Event
-    return sse(result.textStream) // [!code ++]
+    return sse(stream.textStream) // [!code ++]
 
     // UI Message Stream is also supported
-    return sse(result.toUIMessageStream()) // [!code ++]
+    return sse(stream.toUIMessageStream()) // [!code ++]
 })
 ```
 
@@ -84,10 +84,10 @@ new Elysia().get('/', () => {
         prompt: 'Hi! How are you doing?'
     })
 
-    return result.toTextStreamResponse() // [!code ++]
+    return stream.toTextStreamResponse() // [!code ++]
 
     // UI Message Stream Response will use SSE
-    return result.toUIMessageStreamResponse() // [!code ++]
+    return stream.toUIMessageStreamResponse() // [!code ++]
 })
 ```
 
@@ -107,7 +107,7 @@ new Elysia().get('/', async function* () {
         prompt: 'Hi! How are you doing?'
     })
 
-    for await (const data of result.textStream) // [!code ++]
+    for await (const data of stream.textStream) // [!code ++]
         yield sse({ // [!code ++]
             data, // [!code ++]
             event: 'message' // [!code ++]


### PR DESCRIPTION
s/result/stream

verified with:

1. editor inline TS auto-complete
2. when I bun run the program, the program is valid and returns results for the handlers


<img width="259" height="417" alt="image" src="https://github.com/user-attachments/assets/e86f6171-8bb9-44c1-87bb-489a1c69d53f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI SDK integration guide to standardize streaming examples, replacing result-based references with stream-based usage.
  * Aligned code snippets for text streaming and UI message streaming to use stream.textStream and stream.toUIMessageStream.
  * Clarified SSE and UI integration examples for consistent, up-to-date streaming patterns.
  * Improves clarity and consistency for developers implementing streaming features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->