### PR TITLE
Update openapi.md scalar documentation

### DIFF
--- a/docs/plugins/openapi.md
+++ b/docs/plugins/openapi.md
@@ -170,11 +170,13 @@ Scalar configuration, refers to [Scalar config](https://github.com/scalar/scalar
 
 Self-host the Scalar bundle and disable CDN Fonts.
 
+Note: `cdn` is an Elysia OpenAPI plugin option (not part of Scalar’s own config); it overrides the URI to the Scalar bundle.
+
 ```typescript
     openapi({ 
       scalar: {
-        cdn: "/public/scalar-standalone.min.js", //Self-hosted
-        withDefaultFonts: false, //Disable CDN Fonts
+        cdn: "/public/scalar-standalone.min.js", // plugin override for Scalar bundle URI (self-hosted)
+        withDefaultFonts: false, // disable Scalar’s default font CDN
       },
     })
 ```


### PR DESCRIPTION
`cdn` is not part of the official Scalar configuration, but it is part of the Scalar plugin and provides a means of overriding the scalar URI to the scalar bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Self-hosted Scalar bundle” subsection to the OpenAPI plugin docs.
  * Shows how to configure a custom self-hosted CDN path for the Scalar bundle.
  * Demonstrates disabling default fonts for greater styling control.
  * Clarifies options for hosting assets locally and adjusting appearance.
  * Documentation-only; no functional changes to the product.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->