### PR TITLE
docs: remove extra quote in status 418 example

### DIFF
--- a/docs/tutorial/getting-started/status-and-headers/index.md
+++ b/docs/tutorial/getting-started/status-and-headers/index.md
@@ -48,7 +48,7 @@ You can also return a status code by return your response in a `status` function
 import { Elysia } from 'elysia'
 
 new Elysia()
-	.get('/', ({ status }) => status(418, "I'm a teapot'"))
+	.get('/', ({ status }) => status(418, "I'm a teapot"))
 	.listen(3000)
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the Getting Started tutorial for status and headers: updated the example response text from "I'm a teapot'" to "I'm a teapot" (removed stray apostrophe).
  * Improves readability and accuracy of the example, aligning sample output with expected string formatting.
  * Helps prevent confusion for users copying code snippets; no behavioral changes to examples or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->