### PR TITLE
fix: Typo in tanstack-start.md

### DIFF
--- a/docs/integrations/tanstack-start.md
+++ b/docs/integrations/tanstack-start.md
@@ -16,7 +16,7 @@ head:
 
 # Integration with Tanstack Start
 
-Elysia can runs inside Tanstack Start server routes.
+Elysia can run inside Tanstack Start server routes.
 
 1. Create **src/routes/api.$.ts**
 2. Define an Elysia server


### PR DESCRIPTION
Saw this in tweet
<img width="1182" height="1160" alt="CleanShot 2025-10-13 at 12 30 08@2x" src="https://github.com/user-attachments/assets/71a41a8a-11db-4f11-b35f-81df246d50d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Corrected grammar in the integration guide describing how the framework can run inside TanStack Start server routes, improving clarity and readability.
  * Refined phrasing for a more precise, professional explanation of the setup, helping reduce potential confusion during integration.
  * No behavioral, configuration, or API changes; this update is solely to improve documentation quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->