### PR TITLE
Fix thrown error class to NicheError in error-handling tutorial,

### DIFF
--- a/docs/tutorial/patterns/error-handling/index.md
+++ b/docs/tutorial/patterns/error-handling/index.md
@@ -78,7 +78,7 @@ new Elysia()
 		}
 	})
 	.get('/', () => {
-		throw new NicheError('Custom error message')
+        throw new NicheError('Custom error message')
 	})
 	.listen(3000)
 ```


### PR DESCRIPTION
fix wrong class error call

btw, using 

```typescript
if(code === "NOT_FOUND")
```

cause an error

```
ReferenceError: _r_r is not defined
    at he.eval [as handleError] (eval at vn (https://esm.sh/elysia@1.4.11/es2022/elysia.mjs:338:104), <anonymous>:14:44)
    at map (eval at Zt (https://esm.sh/elysia@1.4.11/es2022/elysia.mjs:308:43), <anonymous>:35:12)
    at he.fetch (https://esm.sh/elysia@1.4.11/es2022/elysia.mjs:349:12354)
    at he.handle (https://esm.sh/elysia@1.4.11/es2022/elysia.mjs:349:12285)
    at self.onmessage (blob:https://elysiajs.com/3c40943f-9e0a-4365-90db-487686878d7e:89:32)
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the error-handling tutorial for consistency, using a single custom error type across route examples and onError handling.
  * Clarified code samples to better illustrate error-code-based type narrowing.
  * No functional or API changes; this is a content improvement to align examples and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->