### PR TITLE
fix: clean up classes on glare card dismiss

### DIFF
--- a/docs/.vitepress/theme/glare-card/glare-card.vue
+++ b/docs/.vitepress/theme/glare-card/glare-card.vue
@@ -82,6 +82,8 @@ import Card from './card.vue'
 const model = defineModel({ default: false })
 
 watch(model, (value) => {
+    if (typeof window === 'undefined') return
+
     if (value) {
         document.documentElement.classList.add('overflow-hidden')
         document.body.classList.add('overflow-hidden')
@@ -92,6 +94,8 @@ watch(model, (value) => {
 }, { immediate: true })
 
 onBeforeUnmount(() => {
+    if (typeof window === 'undefined') return
+
     document.documentElement.classList.remove('overflow-hidden')
     document.body.classList.remove('overflow-hidden')
 })


### PR DESCRIPTION
Previously, after dismissing the glare card (Nice kirakira card BTW! 😉), the `overflow-hidden` on `body` was not cleaned up, which made the page not scrollable. This pull request tries to fix that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents page scrolling when the glare card is open and restores it on close.
  * Ensures clicking the overlay reliably closes the glare card.
  * Sets the glare card to be closed by default on initial load.

* **Refactor**
  * Simplifies and stabilizes glare card state handling with reactive updates and lifecycle cleanup for more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->