### PR TITLE
Fix grammatical error in Elysia description

### DIFF
--- a/docs/playground/index.md
+++ b/docs/playground/index.md
@@ -28,6 +28,6 @@ It's great to have you here! This playground is designed to help you get started
 
 Unlike traditional backend framework, Elysia can also run in a browser! Allowing you to write, and try out Elysia directly in your browser! making it a perfect environment for learning and experimentation.
 
-Elysia is an ergonomic web frameworks for humans.
+Elysia is an ergonomic web framework for humans.
 
 </Playground>


### PR DESCRIPTION
Fixing grammatical error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in the playground documentation by correcting a grammatical issue, changing a reference from plural to singular when describing Elysia as a web framework.
  * No functional or behavioral changes; this update purely refines wording for readability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->