### PR TITLE
Fix typo in Eden Treaty description

### DIFF
--- a/docs/eden/overview.md
+++ b/docs/eden/overview.md
@@ -57,7 +57,7 @@ Eden is an RPC-like client to connect Elysia with **end-to-end type safety** usi
 It allows you to sync client and server types effortlessly, weighing less than 2KB.
 
 Eden consists of 2 modules:
-1. Eden Treaty **(recommended)**: an improved version RPC version of Eden Treaty
+1. Eden Treaty **(recommended)**: an improved RPC version of Eden Treaty
 2. Eden Fetch: Fetch-like client with type safety
 
 Below is an overview, use-case and comparison for each module.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Eden Treaty wording to state it is an "RPC version" rather than an "RFC version" for clarity in the overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->