### PR TITLE
Fix formatting of bun build command in deploy.md

### DIFF
--- a/docs/patterns/deploy.md
+++ b/docs/patterns/deploy.md
@@ -63,7 +63,7 @@ bun build \
 	--compile \
 	--minify-whitespace \
 	--minify-syntax \
-	--target bun
+	--target bun \
 	--outfile server \
 	src/index.ts
 ```


### PR DESCRIPTION
Fix: Add missing line continuation in bun build command

The original multi-line bun build script was missing a line continuation (\) after the --target bun flag. Due to this, the next line (--outfile server) was not treated as being part of the same command, and Bun interpreted it incorrectly.

This patch fixes the issue by adding the missing backslash so that all flags and arguments are correctly sent to bun build.

Why it's important:

Prevents build-time errors due to incorrectly formatted CLI input

Makes the command easier to read and maintain

Matches conventional shell scripting standards

Verified that the build now works with all flags enabled:

Compiled output

Minified whitespace and syntax

Targeting Bun runtime

Custom output file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor formatting update to deployment documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->