### PR TITLE
fix(docs): typo

### DIFF
--- a/docs/migrate/from-hono.md
+++ b/docs/migrate/from-hono.md
@@ -929,7 +929,7 @@ const app = new Elysia()
 
 Both has a encapsulate mechanism of a plugin to prevent side-effect.
 
-However, Elysia can explicitly stated which plugin should have side-effect by declaring a scoped while Fastify always encapsulate it.
+However, Elysia can explicitly stated which plugin should have side-effect by declaring a scoped while Hono always encapsulate it.
 
 ```ts [Elysia]
 import { Elysia } from 'elysia'


### PR DESCRIPTION
should be Hono instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide with a textual correction clarifying encapsulation behavior comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->