### PR TITLE
fix: code typo on error handling tutorial

### DIFF
--- a/docs/tutorial/patterns/error-handling/index.md
+++ b/docs/tutorial/patterns/error-handling/index.md
@@ -40,7 +40,7 @@ It accept **context** similar to handler but include an additional:
 import { Elysia } from 'elysia'
 
 new Elysia()
-	.onError(({ error, code }) => {
+	.onError(({ code, status }) => {
 		if(code === "NOT_FOUND")
 			return 'uhe~ are you lost?'
 


### PR DESCRIPTION
the code is calling `status()` function from the context, but the handler parameter missed it.

```diff
```typescript
import { Elysia } from 'elysia'

new Elysia()
-	.onError(({ error, code }) => {
+	.onError(({ code, status }) => { // get `status`
		if(code === "NOT_FOUND")
			return 'uhe~ are you lost?'

		return status(418, "My bad! But I\'m cute so you'll forgive me, right?") // where the error happens
	})
	.get('/', () => 'ok')
	.listen(3000)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated error handler callback parameter structure. The error handler now receives `code` and `status` instead of `error` and `code`, providing direct access to response status for improved error response customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->