### PR TITLE
fix: code error on 'extends context' tutorial

### DIFF
--- a/docs/tutorial/patterns/extends-context/index.md
+++ b/docs/tutorial/patterns/extends-context/index.md
@@ -69,7 +69,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
 	.state('count', 0)
-	.get('/', ({ store } }) => {
+	.get('/', ({ store }) => {
 		store.count++
 
 		return store.count


### PR DESCRIPTION
As stated in [`State`](https://elysiajs.com/patterns/extends-context.html#state) document, it has entrypoint named `store` and doesn't expose any other properties _directly_ under the Context.

so it must be `store.count`, instead of `count`, in order to actually reflect the change(`++`) back to the store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial examples to show using the shared store object in handlers and routes: handlers now access and update state via the store, and examples return the store's updated value so routes reflect shared state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->