### PR TITLE
📘 doc: add elysia-csrf plugin

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -119,6 +119,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [Elysia Background](https://github.com/staciax/elysia-background) - A background task processing plugin for Elysia.js
 -   [@fedify/elysia](https://github.com/fedify-dev/fedify/tree/main/packages/elysia) - A plugin that provides seamless integration with [Fedify](https://fedify.dev/), the ActivityPub server framework.
 -   [elysia-healthcheck](https://github.com/iam-medvedev/elysia-healthcheck) - Healthcheck plugin for Elysia.js
+-   [elysia-csrf](https://github.com/lauhon/elysia-csrf) - A CSRF plugin, ported from [express-csrf](https://github.com/expressjs/csurf)
 
 ## Complementary projects:
 


### PR DESCRIPTION
I created a small plugin that does CSRF Token Checks

It should behave exactly like https://github.com/expressjs/csurf or https://github.com/birdofpreyru/csurf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added elysia-csrf as a new official plugin entry to the Plugins Overview, including GitHub URL and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->