### PR TITLE
fix(docs): update route for deploy to prod link

### DIFF
--- a/docs/table-of-content.md
+++ b/docs/table-of-content.md
@@ -131,7 +131,7 @@ If you feels like exploring more Elysia feature, check out:
     <Card title="Open Telemetry" href="/eden/opentelemetry">
    		Learn how to monitor your application with Open Telemetry
     </Card>
-    <Card title="Deploy to Production" href="/patterns/deploys">
+    <Card title="Deploy to Production" href="/patterns/deploy">
     	Learn how to deploy Elysia to production
     </Card>
 </Deck>


### PR DESCRIPTION
Currently the deploy to production link from table of contents is broken -> misdirects to a non existing page

<img width="1597" height="1015" alt="Screenshot 2025-10-22 at 4 35 15 in the afternoon" src="https://github.com/user-attachments/assets/92839a4e-695d-4c03-8591-fbe7068a2892" />
