### PR TITLE
docs: fix comparison titles in migration cards in ```tutorial/whats-next.md```

### DIFF
--- a/docs/tutorial/whats-next.md
+++ b/docs/tutorial/whats-next.md
@@ -80,13 +80,13 @@ If you have used other popular frameworks like Express, Fastify, or Hono, you wi
 
 <Deck>
 	<Card title="From Express" href="/migrate/from-express">
-		Comparison between tRPC and Elysia
+		Comparison between Express and Elysia
 	</Card>
     <Card title="From Fastify" href="/migrate/from-fastify">
   		Comparison between Fastify and Elysia
     </Card>
     <Card title="From Hono" href="/migrate/from-hono">
-  		Comparison between tRPC and Elysia
+  		Comparison between Hono and Elysia
     </Card>
     <Card title="From tRPC" href="/migrate/from-trpc">
   		Comparison between tRPC and Elysia


### PR DESCRIPTION
Updated ```tRPC``` being listed instead of ```Express``` and ```Hono``` under ```From Express``` and ```From Hono``` cards  in ```From other Framework?``` deck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework comparison labels in the "From other Framework?" section to accurately reflect Express and Hono comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->