### PR TITLE
Center the Elysia chan button icon in mobile header

### DIFF
--- a/docs/.vitepress/theme/layout.vue
+++ b/docs/.vitepress/theme/layout.vue
@@ -341,7 +341,7 @@ function toggleAIForCurrentPage() {
 
         <template #nav-bar-content-before>
             <button
-                class="clicky block lg:hidden size-10 ml-4 px-3 py-0-.25 text-cyan-400 dark:text-cyan-300 font-medium bg-cyan-300/10 dark:bg-cyan-300/5 rounded-xl"
+                class="clicky block lg:hidden size-10 ml-4 grid place-items-center text-cyan-400 dark:text-cyan-300 font-medium bg-cyan-300/10 dark:bg-cyan-300/5 rounded-xl"
                 @click="toggleAIDesktop"
             >
                 <Sparkles :size="21" stroke-width="1.5" />


### PR DESCRIPTION
Before
<img width="666" height="83" alt="image" src="https://github.com/user-attachments/assets/a3f78177-1d50-430d-8ada-876b28636bfd" />

After
<img width="677" height="71" alt="image" src="https://github.com/user-attachments/assets/0bb768cd-f5da-49b4-9f28-f7d0f7e3f42f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nav-bar content button styling and alignment for improved layout presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->