### PR TITLE
Fix repeated description

### DIFF
--- a/docs/table-of-content.md
+++ b/docs/table-of-content.md
@@ -79,13 +79,13 @@ If you have used other popular frameworks like Express, Fastify, or Hono, you wi
 
 <Deck>
 	<Card title="From Express" href="/migrate/from-express">
-		Comparison between tRPC and Elysia
+		Comparison between Express and Elysia
 	</Card>
     <Card title="From Fastify" href="/migrate/from-fastify">
   		Comparison between Fastify and Elysia
     </Card>
     <Card title="From Hono" href="/migrate/from-hono">
-  		Comparison between tRPC and Elysia
+  		Comparison between Hono and Elysia
     </Card>
     <Card title="From tRPC" href="/migrate/from-trpc">
   		Comparison between tRPC and Elysia


### PR DESCRIPTION
I've noticed that in the "From other frameworks?" section of each comparison card, multiple descriptions are repeated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Fixed comparison descriptions to correctly identify source frameworks in migration guides, ensuring accurate documentation for users transitioning from Express or Hono.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->