### PR TITLE
docs: change GET to POST for sign-in endpoint

### DIFF
--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -60,7 +60,7 @@ import { Auth } from './service'
 import { AuthModel } from './model'
 
 export const auth = new Elysia({ prefix: '/auth' })
-	.get(
+	.post(
 		'/sign-in',
 		async ({ body, cookie: { session } }) => {
 			const response = await Auth.signIn(body)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication best practices example to use POST method for sign-in requests instead of GET, reflecting proper REST semantics for credential submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->