### PR TITLE
Fix overview.md typo

### DIFF
--- a/docs/eden/overview.md
+++ b/docs/eden/overview.md
@@ -57,7 +57,7 @@ Eden is an RPC-like client to connect Elysia with **end-to-end type safety** usi
 It allows you to sync client and server types effortlessly, weighing less than 2KB.
 
 Eden consists of 2 modules:
-1. Eden Treaty **(recommended)**: an improved RPC version of Eden Treaty
+1. Eden Treaty **(recommended)**: an improved RPC version of Eden Fetch
 2. Eden Fetch: Fetch-like client with type safety
 
 Below is an overview, use-case and comparison for each module.


### PR DESCRIPTION
Eden Treaty is an improved RPC version of Eden Fetch, not Eden Treaty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected references in the Eden Treaty module documentation to accurately reflect that Eden Treaty is an improved RPC version of Eden Fetch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->