### PR TITLE
fix: switched assignement for mount and openapi features in tutorial

### DIFF
--- a/docs/tutorial/features/mount/index.md
+++ b/docs/tutorial/features/mount/index.md
@@ -50,10 +50,8 @@ This allows us to gradually migrate our application to Elysia, or use multiple f
 
 ## Assignment
 
-Let's use the preview to **GET '/openapi'**, and see how our API documentation looks like.
+Let's use the preview to **GET '/hono'** to see if our Hono route is working.
 
-This API documentation is reflected from your code.
-
-Try to modify the code and see how the documentation changes!
+Try to modify the code and see how it changes!
 
 </Editor>

--- a/docs/tutorial/features/openapi/index.md
+++ b/docs/tutorial/features/openapi/index.md
@@ -156,8 +156,10 @@ bun run dev
 
 ## Assignment
 
-Let's use the preview to **GET '/hono'** to see if our Hono route is working.
+Let's use the preview to **GET '/openapi'**, and see how our API documentation looks like.
 
-Try to modify the code and see how it changes!
+This API documentation is reflected from your code.
+
+Try to modify the code and see how the documentation changes!
 
 </Editor>


### PR DESCRIPTION
Tjhe assignments in mount and openapi features tutorials are switched. This PR switch the assignment back in their good place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial assignment instructions with corrected endpoint references in both mount and OpenAPI sections for improved accuracy
  * Added explicit clarification explaining how API documentation automatically reflects code changes when users modify their code
  * Enhanced tutorial guidance to better support interactive learning through code modification exercises

<!-- end of auto-generated comment: release notes by coderabbit.ai -->