### PR TITLE
docs: fix typo on index.md

### DIFF
--- a/docs/tutorial/getting-started/status-and-headers/index.md
+++ b/docs/tutorial/getting-started/status-and-headers/index.md
@@ -93,7 +93,7 @@ See <DocLink href="/essential/handler#set-headers">Headers</DocLink>.
 
 ## Assignment
 
-Let's execrise what we have learned.
+Let's exercise what we have learned.
 
 <template #answer>
 

--- a/docs/tutorial/getting-started/validation/index.md
+++ b/docs/tutorial/getting-started/validation/index.md
@@ -121,7 +121,7 @@ See <DocLink href="/essential/validation#response">Response Validation</DocLink>
 
 ## Assignment
 
-Let's execrise what we have learned.
+Let's exercise what we have learned.
 
 <template #answer>
 


### PR DESCRIPTION
I fixed a small typo I found in the Let’s Get Started Playground while using it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling errors in tutorial documentation to improve clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->