### PR TITLE
docs: fix typo in 'validation' page

### DIFF
--- a/docs/essential/validation.md
+++ b/docs/essential/validation.md
@@ -325,7 +325,7 @@ new Elysia()
 By providing a file type, Elysia will automatically assume that the content-type is `multipart/form-data`.
 
 ### File (Standard Schema)
-If you're using Standard Schema, it's important that Elysia will not be able to valiate content type automatically similar to `t.File`.
+If you're using Standard Schema, it's important that Elysia will not be able to validate content type automatically similar to `t.File`.
 
 But Elysia export a `fileType` that can be used to validate file type by using magic number.
 


### PR DESCRIPTION
I noticed a small typo and fixed it.
Please take a look when you have time.

This is my first OSS contribution, so if I made any mistakes, I’d appreciate your advice.

Have a nice day!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a spelling error in the validation documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->