### PR TITLE
docs: Add elysia-local-https plugin to overview

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -120,6 +120,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [@fedify/elysia](https://github.com/fedify-dev/fedify/tree/main/packages/elysia) - A plugin that provides seamless integration with [Fedify](https://fedify.dev/), the ActivityPub server framework.
 -   [elysia-healthcheck](https://github.com/iam-medvedev/elysia-healthcheck) - Healthcheck plugin for Elysia.js
 -   [elysia-csrf](https://github.com/lauhon/elysia-csrf) - A CSRF plugin, ported from [express-csrf](https://github.com/expressjs/csurf)
+-   [elysia-local-https](https://github.com/mrtcmn/elysia-local-https) - Automatic local HTTPS for Elysia — certs generated, managed, and refreshed in one line.
 
 ## Complementary projects:
 


### PR DESCRIPTION
> Zero-config local HTTPS for Elysia apps. This plugin automatically generates trusted SSL certificates using mkcert, handles certificate renewal, and seamlessly injects TLS configuration into your app.listen() call. Just wrap your listen options and you're secure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the official plugins list to include elysia-local-https as a newly available plugin option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->