### PR TITLE
Fix inconsistent naming in TanStack Start integration docs

### DIFF
--- a/docs/integrations/tanstack-start.md
+++ b/docs/integrations/tanstack-start.md
@@ -80,7 +80,7 @@ export const Route = createFileRoute('/api/$')({
 	}
 })
 
-export const api = createIsomorphicFn() // [!code ++]
+export const getTreaty = createIsomorphicFn() // [!code ++]
 	.server(() => treaty(app).api) // [!code ++]
 	.client(() => treaty<typeof app>('localhost:3000').api) // [!code ++]
 ```


### PR DESCRIPTION
## Summary
Fixed inconsistent export naming in the TanStack Start integration documentation.

## Changes
- Changed `export const api` to `export const getTreaty` in the Eden setup example

## Rationale
The documentation showed exporting a constant named `api`, but all usage examples (Loader Data and React Query sections) referenced `getTreaty`. This inconsistency could confuse developers following the guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Tanstack Start integration guide with clarified API export naming in code examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->