### PR TITLE
Change route handler from 'hi' to 'root'

### DIFF
--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -188,7 +188,7 @@ abstract class Controller {
 }
 
 new Elysia()
-    .get('/', Controller.hi)
+    .get('/', Controller.root)
 ```
 
 This approach makes it hard to type `Context` properly, and may lead to loss of type integrity.


### PR DESCRIPTION
Updated route handler from 'hi' to 'root' for better clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in the best practices guide to demonstrate the current recommended approach for route handler implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->