### PR TITLE
docs: fix open telemetry broken link

### DIFF
--- a/docs/tutorial/whats-next.md
+++ b/docs/tutorial/whats-next.md
@@ -130,7 +130,7 @@ If you feels like exploring more Elysia feature, check out:
     <Card title="Eden" href="/eden/overview">
     	Learn more about Eden, and how to use it effectively
     </Card>
-    <Card title="Open Telemetry" href="/eden/opentelemetry">
+    <Card title="Open Telemetry" href="/patterns/opentelemetry">
    		Learn how to monitor your application with Open Telemetry
     </Card>
     <Card title="Deploy to Production" href="/patterns/deploys">


### PR DESCRIPTION
Fixes the broken link to open telemetry on the "What's next" page of the interactive tutorial