### PR TITLE
docs(tutorial): clarify status function accepts number or string

### DIFF
--- a/docs/tutorial/getting-started/status-and-headers/index.md
+++ b/docs/tutorial/getting-started/status-and-headers/index.md
@@ -49,9 +49,18 @@ You can also return a status code by returning your response using a `status` fu
 import { Elysia } from 'elysia'
 
 new Elysia()
-	.get('/', ({ status }) => status(418, "I'm a teapot'"))
+	.get('/', ({ status }) => status(418, "I'm a teapot"))
 	.listen(3000)
 ```
+
+The status code can be a number or a string status name. Both of these are equivalent:
+
+```typescript
+status(418, "I'm a teapot")
+status("I'm a teapot", "I'm a teapot")
+```
+
+String status names provide TypeScript autocompletion for all valid HTTP statuses.
 
 See <DocLink href="/essential/handler#status">Status</DocLink>.
 


### PR DESCRIPTION
This updates the status-and-headers tutorial to clarify that the `status()` function accepts both numeric status codes and string status names.

The change adds an explanation showing both forms are equivalent:

```typescript
status(418, "I'm a teapot")
status("I'm a teapot", "I'm a teapot")
```

This builds on https://github.com/elysiajs/elysia/pull/1062 to make it clearer to users that they can use either a number or a string status name, with TypeScript providing autocompletion for all valid HTTP status names.

Also fixes a minor typo in the existing code example (extra quote character).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the status() code example.
  * Enhanced documentation showing that status() accepts both numeric status codes and string status names.
  * Included multiple usage examples clearly demonstrating both parameter formats.
  * Documented TypeScript autocompletion support for valid HTTP status names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->