### PR TITLE
docs(patterns): show string status names in error handling examples

### DIFF
--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -28,11 +28,11 @@ const demo = new Elysia()
 	})
     .get('/throw', ({ error }) => {
 		// This will be caught by onError
-		throw error(418)
+		throw error(418) // or error("I'm a teapot")
 	})
 	.get('/return', ({ status }) => {
 		// This will NOT be caught by onError
-		return status(418)
+		return status(418) // or status("I'm a teapot")
 	})
 
 const demo2 = new Elysia()
@@ -300,11 +300,11 @@ new Elysia()
     })
     .get('/throw', ({ status }) => {
         // This will be caught by onError
-        throw status(418)
+        throw status(418) // or status("I'm a teapot")
     })
     .get('/return', ({ status }) => {
         // This will NOT be caught by onError
-        return status(418)
+        return status(418) // or status("I'm a teapot")
     })
 ```
 


### PR DESCRIPTION
This updates the error handling pattern documentation to show that the `status()` and `error()` functions accept both numeric codes and string status names.

Changes:
- Added inline comments showing string alternatives in the script setup code
- Added inline comments in the code example section

This is part of a series of documentation updates to clarify status function usage:
- #734: status-and-headers tutorial
- #735: lifecycle tutorial and essential docs