### PR TITLE
fix: correct quote typos in status examples

### DIFF
--- a/docs/tutorial/getting-started/status-and-headers/index.md
+++ b/docs/tutorial/getting-started/status-and-headers/index.md
@@ -49,7 +49,7 @@ You can also return a status code by returning your response using a `status` fu
 import { Elysia } from 'elysia'
 
 new Elysia()
-	.get('/', ({ status }) => status(418, "I'm a teapot'"))
+	.get('/', ({ status }) => status(418, "I'm a teapot"))
 	.listen(3000)
 ```
 

--- a/docs/tutorial/patterns/error-handling/index.md
+++ b/docs/tutorial/patterns/error-handling/index.md
@@ -45,7 +45,7 @@ new Elysia()
 		if(code === "NOT_FOUND")
 			return 'uhe~ are you lost?'
 
-		return status(418, "My bad! But I\'m cute so you'll forgive me, right?")
+		return status(418, "My bad! But I'm cute so you'll forgive me, right?")
 	})
 	.get('/', () => 'ok')
 	.listen(3000)


### PR DESCRIPTION
Fixes two quote-related typos in status function examples:
- Remove extra trailing quote in teapot example (`"I'm a teapot'"` → `"I'm a teapot"`)
- Remove unnecessary escaped apostrophe in double-quoted string (`I\'m` → `I'm`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed string formatting errors in tutorial code examples to ensure proper syntax for HTTP status codes and error handling patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->