### PR TITLE
fix: correct validation tutorial answer

### DIFF
--- a/docs/tutorial/getting-started/validation/index.md
+++ b/docs/tutorial/getting-started/validation/index.md
@@ -128,15 +128,18 @@ Let's exercise what we have learned.
 We can define a schema by using `t.Object` provide to `body` property.
 
 ```typescript
-import { Elysia } from 'elysia'
+import { Elysia, t } from 'elysia'
 
 new Elysia()
-	.get('/', ({ status, set }) => {
-		set.headers['x-powered-by'] = 'Elysia'
-
-		return status(418, 'Hello Elysia!')
-	})
-	.get('/docs', ({ redirect }) => redirect('https://elysiajs.com'))
+	.post(
+		'/user',
+		({ body: { name } }) => `Hello ${name}!`,
+		{
+			body: t.Object({
+				name: t.String()
+			})
+		}
+	)
 	.listen(3000)
 ```
 


### PR DESCRIPTION
The validation tutorial's assignment's answer section showed unrelated code from a previous tutorial.

This fixes the answer to properly demonstrate the solution: importing `t` from elysia, using `.post('/user', ...)` with a third argument containing `body: t.Object({ name: t.String() })`. Now the answer matches what the assignment asks for and what the automated test cases in `data.ts` expect.