### PR TITLE
docs: use string status names in code examples

### DIFF
--- a/docs/eden/treaty/response.md
+++ b/docs/eden/treaty/response.md
@@ -30,7 +30,7 @@ import { treaty } from '@elysiajs/eden'
 
 const app = new Elysia()
     .post('/user', ({ body: { name }, status }) => {
-        if(name === 'Otto') return status(400)
+        if(name === 'Otto') return status('Bad Request')
 
         return name
     }, {
@@ -146,7 +146,7 @@ import { treaty, Treaty } from '@elysiajs/eden'
 
 const app = new Elysia()
 	.post('/user', ({ body: { name }, status }) => {
-		if(name === 'Otto') return status(400)
+		if(name === 'Otto') return status('Bad Request')
 
 		return name
 	}, {

--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -316,7 +316,7 @@ const AuthService = new Elysia({ name: 'Auth.Service' })
     .macro({
         isSignIn: {
             resolve({ cookie, status }) {
-                if (!cookie.session.value) return status(401)
+                if (!cookie.session.value) return status('Unauthorized')
 
                 return {
                 	session: cookie.session.value,
@@ -367,7 +367,7 @@ class AuthService {
 	// ❌ Don't do this
 	isSignIn({ status, cookie: { session } }: Context) {
 		if (session.value)
-			return status(401)
+			return status('Unauthorized')
 	}
 }
 ```
@@ -390,7 +390,7 @@ class AuthService {
 	// ✅ Do
 	isSignIn({ status, cookie: { session } }: InferContext<typeof setup>) {
 		if (session.value)
-			return status(401)
+			return status('Unauthorized')
 	}
 }
 ```

--- a/docs/essential/life-cycle.md
+++ b/docs/essential/life-cycle.md
@@ -502,7 +502,7 @@ import { validateSession } from './user'
 new Elysia()
     .get('/', () => 'hi', {
         beforeHandle({ set, cookie: { session }, status }) {
-            if (!validateSession(session.value)) return status(401)
+            if (!validateSession(session.value)) return status('Unauthorized')
         }
     })
     .listen(3000)
@@ -527,7 +527,7 @@ new Elysia()
     .guard(
         {
             beforeHandle({ set, cookie: { session }, status }) {
-                if (!validateSession(session.value)) return status(401)
+                if (!validateSession(session.value)) return status('Unauthorized')
             }
         },
         (app) =>

--- a/docs/essential/plugin.md
+++ b/docs/essential/plugin.md
@@ -115,8 +115,8 @@ const _mock3 = {
 }
 
 const profile1 = new Elysia()
-	.onBeforeHandle(({ status }) => status(401))
-	.get('/profile', ({ status }) => status(401))
+	.onBeforeHandle(({ status }) => status('Unauthorized'))
+	.get('/profile', ({ status }) => status('Unauthorized'))
 
 const scope1 = new Elysia()
 	.use(profile1)
@@ -124,13 +124,13 @@ const scope1 = new Elysia()
 	.patch('/rename', () => 'Updated!')
 
 const profile2 = new Elysia()
-	.onBeforeHandle({ as: 'global' }, ({ status }) => status(401))
-	.get('/profile', ({ status }) => status(401))
+	.onBeforeHandle({ as: 'global' }, ({ status }) => status('Unauthorized'))
+	.get('/profile', ({ status }) => status('Unauthorized'))
 
 const scope2 = new Elysia()
 	.use(profile2)
 	// This will NOT have sign in check
-	.patch('/rename', ({ status }) => status(401))
+	.patch('/rename', ({ status }) => status('Unauthorized'))
 </script>
 
 # Plugin <TutorialBadge href="/tutorial/getting-started/plugin" />

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,7 @@ const role = new Elysia({ name: 'macro' })
 		role: (type: 'user' | 'staff' | 'admin') => ({
 			beforeHandle({ headers, status }) {
 				if(headers.authorization !== type)
-					return status(401)
+					return status('Unauthorized')
 			}
 		})
 	})
@@ -159,7 +159,7 @@ export const auth = new Elysia()
 			ssid: t.String()
 		}),
 		resolve({ cookie, status }) {
-			if(!cookie.ssid.value) return status(401)
+			if(!cookie.ssid.value) return status('Unauthorized')
 
 			return {
 				user: cookie.ssid.value
@@ -189,7 +189,7 @@ export const auth = new Elysia()
 			ssid: t.String()
 		}),
 		resolve({ cookie, status }) {
-			if(!cookie.ssid.value) return status(401)
+			if(!cookie.ssid.value) return status('Unauthorized')
 
 			return {
 				user: cookie.ssid.value

--- a/docs/integrations/better-auth.md
+++ b/docs/integrations/better-auth.md
@@ -189,7 +189,7 @@ const betterAuth = new Elysia({ name: 'better-auth' })
                     headers
                 })
 
-                if (!session) return status(401)
+                if (!session) return status('Unauthorized')
 
                 return {
                     user: session.user,

--- a/docs/key-concept.md
+++ b/docs/key-concept.md
@@ -19,8 +19,8 @@ import { Elysia } from 'elysia'
 import Playground from './components/nearl/playground.vue'
 
 const profile1 = new Elysia()
-	.onBeforeHandle(({ status }) => status(401))
-	.get('/profile', ({ status }) => status(401))
+	.onBeforeHandle(({ status }) => status('Unauthorized'))
+	.get('/profile', ({ status }) => status('Unauthorized'))
 
 const demo1 = new Elysia()
 	.use(profile1)
@@ -28,13 +28,13 @@ const demo1 = new Elysia()
 	.patch('/rename', () => 'Updated!')
 
 const profile2 = new Elysia()
-	.onBeforeHandle({ as: 'global' }, ({ status }) => status(401))
-	.get('/profile', ({ status }) => status(401))
+	.onBeforeHandle({ as: 'global' }, ({ status }) => status('Unauthorized'))
+	.get('/profile', ({ status }) => status('Unauthorized'))
 
 const demo2 = new Elysia()
 	.use(profile2)
 	// This will NOT have sign in check
-	.patch('/rename', ({ status }) => status(401))
+	.patch('/rename', ({ status }) => status('Unauthorized'))
 </script>
 
 # Key Concept <Badge type="danger" text="MUST READ" />

--- a/docs/patterns/extends-context.md
+++ b/docs/patterns/extends-context.md
@@ -317,7 +317,7 @@ new Elysia()
     .derive(({ headers, status }) => {
         const auth = headers['authorization']
 
-        if(!auth) return status(400)
+        if(!auth) return status('Unauthorized')
 
         return {
             bearer: auth?.startsWith('Bearer ') ? auth.slice(7) : null

--- a/docs/tutorial/getting-started/encapsulation/data.ts
+++ b/docs/tutorial/getting-started/encapsulation/data.ts
@@ -5,7 +5,7 @@ export const code = `import { Elysia, t } from 'elysia'
 const nameCheck = new Elysia()
 	.onBeforeHandle(
 		({ query: { name }, status }) => {
-			if(!name) return status(401)
+			if(!name) return status('Unauthorized')
 		}
 	)
 
@@ -16,7 +16,7 @@ const ageCheck = new Elysia()
 			name: t.Optional(t.String())
 		}),
 		beforeHandle({ query: { age }, status }) {
-			if(age < 18) return status(403)
+			if(age < 18) return status('Forbidden')
 		}
 	})
 

--- a/docs/tutorial/getting-started/encapsulation/index.md
+++ b/docs/tutorial/getting-started/encapsulation/index.md
@@ -30,7 +30,7 @@ const profile1 = new Elysia()
 	.onBeforeHandle(
 		({ query: { name }, status }) => {
 			if(!name)
-				return status(401)
+				return status('Unauthorized')
 		}
 	)
 	.get('/profile', () => 'Hi!')
@@ -44,10 +44,10 @@ const profile2 = new Elysia()
 		{ as: 'global' },
 		({ query: { name }, status }) => {
 			if(!name)
-				return status(401)
+				return status('Unauthorized')
 		}
 	)
-	.get('/profile', ({ status }) => status(401))
+	.get('/profile', ({ status }) => status('Unauthorized'))
 
 const demo2 = new Elysia()
 	.use(profile2)
@@ -70,7 +70,7 @@ const profile = new Elysia()
 	.onBeforeHandle(
 		({ query: { name }, status }) => {
 			if(!name)
-				return status(401)
+				return status('Unauthorized')
 		}
 	)
 	.get('/profile', () => 'Hi!')
@@ -143,7 +143,7 @@ const user = new Elysia()
 			name: t.Optional(t.String())
 		}),
 		beforeHandle({ query: { age }, status }) {
-			if(age < 18) return status(403)
+			if(age < 18) return status('Forbidden')
 		}
 	})
 	.get('/profile', () => 'Hi!')
@@ -171,7 +171,7 @@ const nameCheck = new Elysia()
 	.onBeforeHandle(
 		{ as: 'scoped' }, // [!code ++]
 		({ query: { name }, status }) => {
-			if(!name) return status(401)
+			if(!name) return status('Unauthorized')
 		}
 	)
 
@@ -183,7 +183,7 @@ const ageCheck = new Elysia()
 			name: t.Optional(t.String())
 		}),
 		beforeHandle({ query: { age }, status }) {
-			if(age < 18) return status(403)
+			if(age < 18) return status('Forbidden')
 		}
 	})
 

--- a/docs/tutorial/getting-started/guard/index.md
+++ b/docs/tutorial/getting-started/guard/index.md
@@ -37,7 +37,7 @@ import { Elysia, t } from 'elysia'
 
 new Elysia()
 	.onBeforeHandle(({ query: { name }, status }) => { // [!code --]
-		if(!name) return status(401) // [!code --]
+		if(!name) return status('Unauthorized') // [!code --]
 	}) // [!code --]
 	.onBeforeHandle(({ query: { name } }) => { // [!code --]
 		console.log(name) // [!code --]
@@ -48,7 +48,7 @@ new Elysia()
 	.guard({ // [!code ++]
 		beforeHandle: [ // [!code ++]
 			({ query: { name }, status }) => { // [!code ++]
-				if(!name) return status(401) // [!code ++]
+				if(!name) return status('Unauthorized') // [!code ++]
 			}, // [!code ++]
 			({ query: { name } }) => { // [!code ++]
 				console.log(name) // [!code ++]
@@ -88,7 +88,7 @@ new Elysia()
 	.guard({
 		beforeHandle: [
 			({ query: { name }, status }) => {
-				if(!name) return status(401)
+				if(!name) return status('Unauthorized')
 			},
 			({ query: { name } }) => {
 				console.log(name)
@@ -139,7 +139,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
 	.onBeforeHandle(({ query: { name }, status }) => {
-		if(!name) return status(401)
+		if(!name) return status('Unauthorized')
 	})
 	.get('/auth', ({ query: { name = 'anon' } }) => {
 		return `Hello ${name}!`

--- a/docs/tutorial/getting-started/life-cycle/index.md
+++ b/docs/tutorial/getting-started/life-cycle/index.md
@@ -147,7 +147,7 @@ import { Elysia } from 'elysia'
 
 new Elysia()
 	.onBeforeHandle(({ query: { name }, status }) => {
-		if(!name) return status(401)
+		if(!name) return status('Unauthorized')
 	})
 	.get('/auth', ({ query: { name = 'anon' } }) => {
 		return `Hello ${name}!`

--- a/docs/tutorial/getting-started/validation/index.md
+++ b/docs/tutorial/getting-started/validation/index.md
@@ -134,7 +134,7 @@ new Elysia()
 	.get('/', ({ status, set }) => {
 		set.headers['x-powered-by'] = 'Elysia'
 
-		return status(418, 'Hello Elysia!')
+		return status("I'm a teapot", 'Hello Elysia!')
 	})
 	.get('/docs', ({ redirect }) => redirect('https://elysiajs.com'))
 	.listen(3000)

--- a/docs/tutorial/patterns/extends-context/index.md
+++ b/docs/tutorial/patterns/extends-context/index.md
@@ -161,7 +161,7 @@ new Elysia()
 		)
 	})
 	.resolve(({ query: { age }, status }) => {
-		if(!age) return status(401)
+		if(!age) return status('Unauthorized')
 
 		return { age }
 	})

--- a/docs/tutorial/patterns/macro/index.md
+++ b/docs/tutorial/patterns/macro/index.md
@@ -64,7 +64,7 @@ new Elysia()
 		}),
 		// psuedo auth check
 		beforeHandle({ cookie: { session }, status }) {
-			if(!session.value) return status(401)
+			if(!session.value) return status('Unauthorized')
 		}
 	})
 	.post('/user', ({ body }) => body, {
@@ -112,7 +112,7 @@ new Elysia()
     .macro('isFibonacci', {
 		body: t.Number(),
         beforeHandle({ body, status }) {
-            if(!isFibonacci(body)) return status(418)
+            if(!isFibonacci(body)) return status("I'm a teapot")
         }
     })
 	.post('/', ({ body }) => body, {


### PR DESCRIPTION
This PR converts numeric HTTP status codes to descriptive string names across all documentation examples, making the code more readable and demonstrating Elysia's string status name feature.

The conversions follow a consistent pattern: `status(401)` becomes `status('Unauthorized')`, `status(403)` becomes `status('Forbidden')`, `status(400)` becomes `status('Bad Request')`, and `status(418)` becomes `status("I'm a teapot")`. String status names provide TypeScript autocompletion for all valid HTTP statuses, reducing errors and improving the developer experience.

This consolidates conversion changes from PRs #739, #740, #741, #742, #743, and #744 into a single cohesive PR. Those PRs can be closed once this merges.