### PR TITLE
docs: add contextual notes about string status names

### DIFF
--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -21,6 +21,7 @@ import TutorialBadge from '../components/arona/badge.vue'
 import Card from '../components/nearl/card.vue'
 import Deck from '../components/nearl/card-deck.vue'
 import Playground from '../components/nearl/playground.vue'
+import DocLink from '../components/xiao/doc-link/doc-link.vue'
 
 const demo = new Elysia()
 	.onError(({ code }) => {
@@ -307,6 +308,8 @@ new Elysia()
         return status(418)
     })
 ```
+
+Here we use `status(418)` which is the "I'm a teapot" status code. You can also use the string name directly: `status("I'm a teapot")`. See <DocLink href="/tutorial/getting-started/status-and-headers#status">Status</DocLink> for more on using status codes.
 
 <Playground
     :elysia="demo"

--- a/docs/tutorial/getting-started/life-cycle/index.md
+++ b/docs/tutorial/getting-started/life-cycle/index.md
@@ -62,6 +62,8 @@ new Elysia()
 	.get('/2', () => 'Hello Elysia!')
 ```
 
+Here we use `status(418)` which is the "I'm a teapot" status code. You can also use the string name directly: `status("I'm a teapot")`. See <DocLink href="/tutorial/getting-started/status-and-headers#status">Status</DocLink> for more on using status codes.
+
 When `beforeHandle` returns a value, it will skip the handler and return the value instead.
 
 This is useful for things like authentication, where you want to return a `401 Unauthorized` response if the user is not authenticated.


### PR DESCRIPTION
This PR adds in-context reminders where readers encounter `status(418)` in examples, pointing them to the `status("I'm a teapot")` alternative.

Both link directly to the Status section `/tutorial/getting-started/status-and-headers#status` for readers who want to learn more. PR #738 introduces the general explanation of string status names in the Status and Headers tutorial. 