### PR TITLE
docs: show multiple service patterns with tabs

### DIFF
--- a/docs/key-concept.md
+++ b/docs/key-concept.md
@@ -326,6 +326,10 @@ const app = new Elysia()
 	})
 ```
 
+::: tip
+This example uses an abstract class, but you can also use plain objects, module exports, or namespaces. See [Best Practice: Service patterns](/essential/best-practice.html#1-abstract-away-non-request-dependent-service) for alternatives.
+:::
+
 See [Best practice: MVC Controller](/essential/best-practice.html#controller).
 
 ### TypeScript


### PR DESCRIPTION
The Best Practice page currently shows `abstract class` with static methods for services and `namespace` for models. Rather than prescribing a single pattern, this change presents all four approaches for grouping functions using tabs, letting developers choose based on their background.

The Service section now shows four options in order of simplicity: plain objects (simplest, idiomatic JavaScript), module exports with `import * as` (ES module-native, tree-shakeable), namespaces (TypeScript feature for co-locating types with values), and abstract classes with static methods (familiar to Java/C# developers). All four produce identical runtime behavior; the choice is purely stylistic.

Other locations that show abstract class examples (Controller section, key-concept.md) now include a brief tip callout pointing to the Service patterns section, making it clear that alternatives exist without cluttering the examples. The anti-pattern examples that use abstract class are left unchanged since the grouping pattern isn't the point there.

This aligns with Elysia's stated philosophy of being "pattern-agnostic" and leaving coding pattern decisions to the developer and their team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded best-practice guidance for non-request dependent services with a tab-driven presentation of multiple organization patterns.
  * Added richer examples and inline tips showing object, module, namespace, and class approaches.
  * Clarified that all patterns share the same runtime behavior and recommended choosing based on team familiarity and type colocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->