### PR TITLE
Docs: fix grammar in tutorial intro (Remove redundant adverbs)

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -31,7 +31,7 @@ import { code, testcases } from './data'
 
 It's great to have you here! This playground is will help you get started with Elysia interactively.
 
-Unlike traditional backend framework, **Elysia can also run in a browser** as well! Although it doesn't support all features, it's a perfect environment for learning and experimentation.
+Unlike traditional backend frameworks, **Elysia can run in a browser**! Although it doesn't support all features, it's a perfect environment for learning and experimentation.
 
 You can check out the API docs by clicking <Bookmark class="inline" :size="18" stroke-width="2" /> on the left sidebar.
 


### PR DESCRIPTION
#This PR makes a small wording/grammar improvement in the tutorial intro.

- Change **“framework” → “frameworks”** (plural) for grammatical agreement.
- Remove redundant **“as well”** phrasing.
- Remove **"also"** for clarity and make the sentence more direct.
  “_Unlike traditional backend frameworks, **Elysia can run in a browser**!_”

**Rationale:** “also … as well” is redundant, and keeping “also” can momentarily read as if it’s modifying “frameworks” (implying other frameworks run in the browser too). 
The revised sentence is clearer and more concise without changing meaning.

Even though it’s a small change, this is the very first section new users see in the docs.
Polishing this sentence in the docs helps to fix a first impression to a detailed oriented expectation for people learning the framework.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined grammar and punctuation in tutorial documentation. Enhanced clarity of explanations covering Elysia's cross-platform capabilities and browser compatibility. Improved readability to better communicate the framework's unique features to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->