### PR TITLE
:blue_book: docs: add Nitro preset requirement

### DIFF
--- a/docs/integrations/nuxt.md
+++ b/docs/integrations/nuxt.md
@@ -31,9 +31,16 @@ bun add -d nuxt-elysia
 export default defineNuxtConfig({
     modules: [ // [!code ++]
         'nuxt-elysia' // [!code ++]
-    ] // [!code ++]
+    ], // [!code ++]
+    nitro: { // [!code ++]
+        preset: 'Bun' // [!code ++]
+    } // [!code ++]
 })
 ```
+
+::: tip
+The `nitro.preset: 'Bun'` configuration is required because Elysia runs on Bun runtime. This tells Nuxt's Nitro to use Bun as the server runtime instead of the default Node.js runtime.
+:::
 
 3. Create `api.ts` in the project root:
 


### PR DESCRIPTION
## Overview
This PR updates the Nuxt integration documentation to include the required Nitro configuration with Bun preset.
The documentation now clearly states that `nitro.preset: 'Bun'` is required in the Nuxt config for Elysia to run properly.

## Scope of work
added `nitro.preset: 'Bun'` configuration to the Nuxt config example and tips

## Related Issues
https://github.com/elysiajs/documentation/discussions/552#discussioncomment-15205296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nuxt integration guide with Bun server runtime configuration requirements
  * Added clarification on setting up Bun compatibility for Nuxt projects
  * Included example API endpoint code for reference

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->