### PR TITLE
Docs: Fix grammar to improve clarity in Hono migration guide

### DIFF
--- a/docs/migrate/from-hono.md
+++ b/docs/migrate/from-hono.md
@@ -114,7 +114,7 @@ While Hono use a `c.text`, and `c.json` to warp a response, Elysia map a value t
 
 There is a slight different in style guide, Elysia recommends usage of method chaining and object destructuring.
 
-Hono port allocation is depends on runtime, and adapter while Elysia use a single `listen` method to start the server.
+Hono port allocation depends on runtime, and adapter while Elysia use a single `listen` method to start the server.
 
 ## Handler
 


### PR DESCRIPTION
There was a typo in the docs comparing Hono to Elysia, I removed 'is' to improve the statement's clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed grammar in migration guide documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->