### PR TITLE
docs(deploy): specify Dockerfile path in build command

### DIFF
--- a/docs/patterns/deploy.md
+++ b/docs/patterns/deploy.md
@@ -255,7 +255,7 @@ Assume that our monorepo are using Turborepo with structure as follows:
 
 Then we can build our Dockerfile on monorepo root (not app root):
 ```bash
-docker build -t elysia-mono .
+docker build -f apps/server/Dockerfile -t elysia-mono .
 ```
 
 With Dockerfile as follows:


### PR DESCRIPTION
Updated Docker build command to specify Dockerfile path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation with clarification on Docker build procedures for monorepo configurations, specifying the correct Dockerfile path to use during container builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->