### PR TITLE
docs: update docs for OpenAPI Type Gen support in Cloudflare Workers

### DIFF
--- a/docs/integrations/cloudflare-worker.md
+++ b/docs/integrations/cloudflare-worker.md
@@ -65,7 +65,7 @@ wrangler dev
 
 This should start a development server at `http://localhost:8787`
 
-You don't need a `nodejs_compat` flag as Elysia doesn't use any Node.js built-in modules (or the ones we use don't support Cloudflare Worker yet).
+You don't need a `nodejs_compat` flag for basic usage. However, if you want to use [OpenAPI Type Gen](/blog/openapi-type-gen), you'll need to enable it with compatibility_date 2025-09-01 or later.
 
 ### pnpm
 If you use pnpm, [pnpm doesn't auto install peer dependencies by default](https://github.com/orgs/pnpm/discussions/3995#discussioncomment-1893230) forcing you to install additional dependencies manually.
@@ -76,8 +76,8 @@ pnpm add @sinclair/typebox openapi-types
 ## Limitations
 Here are some known limitations of using Elysia on Cloudflare Worker:
 
-1. `Elysia.file`, and [Static Plugin](/plugins/static) doesn't work [due to the lack of `fs` module](https://developers.cloudflare.com/workers/runtime-apis/nodejs/#supported-nodejs-apis), see [static file](#static-file) section for alternative
-2. [OpenAPI Type Gen](/blog/openapi-type-gen) doesn't work [due to the lack of `fs` module](https://developers.cloudflare.com/workers/runtime-apis/nodejs/#supported-nodejs-apis)
+1. `Elysia.file`, and [Static Plugin](/plugins/static) doesn't work, see [static file](#static-file) section for Cloudflare's built-in alternative
+2. [OpenAPI Type Gen](/blog/openapi-type-gen) requires `nodejs_compat` flag enabled in wrangler config (compatibility_date 2025-09-01 or later)
 3. You can't define [**Response** before server start](https://x.com/saltyAom/status/1966602691754553832) or use plugin that does so
 4. You can't inline a value due to 3.
 


### PR DESCRIPTION
https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudflare Worker integration guidance to clarify when the nodejs_compat flag is required for OpenAPI Type Gen.
  * Enhanced limitations documentation with Cloudflare-specific alternatives for static file handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->