### PR TITLE
Invert password verification condition in Best Practice page

### DIFF
--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -95,7 +95,7 @@ export abstract class Auth {
 			WHERE username = ${username}
 			LIMIT 1`
 
-		if (await Bun.password.verify(password, user.password))
+		if (!await Bun.password.verify(password, user.password))
 			// You can throw an HTTP error directly
 			throw status(
 				400,


### PR DESCRIPTION
The original condition throw 400 error when the password is verified,
thereforce add negate symbol in front of password verify condition negate the result make it right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication check logic in documentation that was incorrectly rejecting valid password verifications. The authentication flow now properly validates credentials and returns appropriate error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->