### PR TITLE
:wrench: fix: change markdown button to copy to clipboard

### DIFF
--- a/docs/.vitepress/theme/layout.vue
+++ b/docs/.vitepress/theme/layout.vue
@@ -121,6 +121,17 @@ function toggleAIForCurrentPage() {
         defaultValue: 'Summarize this page'
     })
 }
+
+async function copyMarkdownToClipboard() {
+    const mdUrl = `https://elysiajs.com${router.route.path.replace(/.html$/g, '')}.md`
+    try {
+        const response = await fetch(mdUrl)
+        const markdown = await response.text()
+        await navigator.clipboard.writeText(markdown)
+    } catch (error) {
+        console.error('Failed to copy markdown:', error)
+    }
+}
 </script>
 
 <template>
@@ -186,15 +197,13 @@ function toggleAIForCurrentPage() {
                         </svg>
                     </a>
 
-                    <a
-                        :href="`https://elysiajs.com${router.route.path.replace(/.html$/g, '')}.md`"
+                    <button
+                        @click="copyMarkdownToClipboard"
                         class="clicky"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        title="Open in Markdown"
+                        title="Copy as Markdown"
                     >
                         <File stroke-width="1.5" />
-                    </a>
+                    </button>
                 </div>
             </div>
         </template>


### PR DESCRIPTION
## Summary
- Changed the "Open in Markdown" button to copy the page's markdown content to clipboard instead of opening in a new tab

## Changes

- Converted the markdown <a> link to a <button> element
- Added copyMarkdownToClipboard() async function that:
  - Fetches the markdown content from the current page's .md URL
  - Copies it to the user's clipboard using the Clipboard API
  - Handles errors gracefully with console logging
- Updated button title from "Open in Markdown" to "Copy as Markdown" to reflect the new behavior

## Why
This makes it easier for users to quickly grab the markdown content for use in AI tools like ChatGPT or Claude without having to navigate to a new tab and manually copy the content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Replaced the "Open in Markdown" link with a "Copy as Markdown" button that copies the current page's Markdown content directly to your clipboard for easy sharing and offline access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->