### PR TITLE
Add Unified Payments SDK to Community Plugins

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -125,7 +125,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [elysia-local-https](https://github.com/mrtcmn/elysia-local-https) - Automatic local HTTPS for Elysia — certs generated, managed, and refreshed in one line.
 -   [Eden TanStack Query](https://github.com/xkelxmc/eden-tanstack-query) - type-safe TanStack Query integration for Eden, like
   @trpc/react-query but for Elysia
--   [Unified Payments SDK](https://github.com/aashahin/payments-sdk) - Unified, framework-agnostic payment SDK for Bun & TypeScript. Seamlessly integrate Moyasar, PayPal, Paymob and other payment gateways with type-safe lifecycle hooks and normalized webhooks.
+-   [Unified Payments SDK](https://github.com/aashahin/payments-sdk) - Unified, framework-agnostic payment SDK for Bun & TypeScript. Seamlessly integrate Moyasar, PayPal, Paymob, Stripe, Tabby and Tamara with type-safe lifecycle hooks and normalized webhooks.
 
 ## Complementary projects:
 


### PR DESCRIPTION
Added `payments-sdk` to the Community plugins section in overview.md. 

This package provides a unified, framework-agnostic payment SDK for Bun & TypeScript, supporting seamless integration with Stripe, PayPal, Moyasar, and Paymob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Official plugins list updated to include the Unified Payments SDK, with its URL and descriptive entry so users can discover, review, and learn about this new payment integration option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->