### PR TITLE
Add LogTape logging middleware to plugins list

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -68,6 +68,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [Elylog](https://github.com/eajr/elylog) - simple stdout logging library with some customization
 -   [Logify for Elysia.js](https://github.com/0xrasla/logify) - a beautiful, fast, and type-safe logging middleware for Elysia.js applications
 -   [Nice Logger](https://github.com/tanishqmanuja/nice-logger) - not the nicest, but a pretty nice and sweet logger for Elysia.
+-   [LogTape for Elysia](https://logtape.org/manual/integrations#elysia) - structured logging middleware with support for multiple sinks (transports) through [LogTape](https://logtape.org/)
 -   [Sentry](https://github.com/johnny-woodtke/elysiajs-sentry) - capture traces and errors with this [Sentry](https://docs.sentry.io/) plugin
 -   [Elysia Lambda](https://github.com/TotalTechGeek/elysia-lambda) - deploy on AWS Lambda
 -   [Decorators](https://github.com/gaurishhs/elysia-decorators) - use TypeScript decorators


### PR DESCRIPTION
Add [LogTape for Elysia](https://logtape.org/manual/integrations#elysia) to the logging section of community plugins. [LogTape](https://logtape.org/) provides structured logging with support for multiple sinks. See also <https://github.com/elysiajs/elysia/discussions/1678> for details!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "LogTape for Elysia" to the official plugins list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->