### PR TITLE
Add elysia-beta-headers plugin to overview

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -125,6 +125,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [elysia-local-https](https://github.com/mrtcmn/elysia-local-https) - Automatic local HTTPS for Elysia — certs generated, managed, and refreshed in one line.
 -   [Eden TanStack Query](https://github.com/xkelxmc/eden-tanstack-query) - type-safe TanStack Query integration for Eden, like
   @trpc/react-query but for Elysia
+- [elysia-beta-headers](https://github.com/P0u4a/elysia-beta-headers) - Elysia plugin for gating your app's beta/experimental features via type-safe API headers
 
 ## Complementary projects:
 


### PR DESCRIPTION
Add [elysia-beta-headers](https://github.com/P0u4a/elysia-beta-headers) to the community plugin list. This plugin allows for creating type-safe feature flags via HTTP headers to request for experimental features to be enabled in your API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added elysia-beta-headers to the official plugins list in the plugin documentation, including its URL and description.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->