### PR TITLE
Fix grammar in sub-router section

### DIFF
--- a/docs/migrate/from-express.md
+++ b/docs/migrate/from-express.md
@@ -174,7 +174,7 @@ const app = new Elysia()
 
 ## Subrouter
 
-Express uses a dedicated `express.Router()` for declaring a sub-router while Elysia treats every instance as a plug-and-play component that can be plug and play together.
+Express uses a dedicated `express.Router()` for declaring a sub-router while Elysia treats every instance as a plug-and-play component that can be composed together.
 
 <Compare>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved wording in the migration guide to enhance readability and flow.
  * Clarified the Subrouter section for more coherent comparison and easier understanding when migrating routing concepts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->