### PR TITLE
docs: fix cloudflare worker link

### DIFF
--- a/docs/internal/jit-compiler.md
+++ b/docs/internal/jit-compiler.md
@@ -125,7 +125,7 @@ When `set` or `status` is not used, Elysia will use `mapCompactResponse` to map 
 
 ## Platform Specific Optimization
 
-Elysia is originally made specifically for Bun but also works on [Node.js](/integrations/node), [Deno](/integrations/deno), [Cloudflare Workers](/integrations/cloudflare-workers) and more.
+Elysia is originally made specifically for Bun but also works on [Node.js](/integrations/node), [Deno](/integrations/deno), [Cloudflare Workers](/integrations/cloudflare-worker) and more.
 
 There are a big difference between being **compatible** and being **optimized** for a specific platform.
 


### PR DESCRIPTION
Corrected the link to Cloudflare Workers in the documentation.

https://elysiajs.com/integrations/cloudflare-worker - no trailing 's'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed Cloudflare Workers integration link reference in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->