### PR TITLE
📘 doc: correct variable reference in sucrose example

### DIFF
--- a/docs/internal/jit-compiler.md
+++ b/docs/internal/jit-compiler.md
@@ -52,7 +52,7 @@ import { Elysia } from 'elysia'
 
 const app = new Elysia()
   .patch('/user/:id', ({ params }) => {
-	return { id: req.params.id }
+	return { id: params.id }
   })
 ```
 


### PR DESCRIPTION
In the Sucrose example, the handler destructures `params` directly from the argument, but the code body attempts to access `req.params.id`

So, I updated the code to use the correct variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in JIT compiler documentation to reflect current API usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->