### PR TITLE
fix(docs): better-auth documentation

### DIFF
--- a/docs/integrations/better-auth.md
+++ b/docs/integrations/better-auth.md
@@ -42,7 +42,7 @@ We need to mount the handler to Elysia endpoint.
 :::note
 Using `all` can prevent unwanted response interception by Better Auth and keep the integrity of OAuth callback URLs.
 
-The `all` method does not auth rewrite the path headers, so we have to manually set the URL here.
+The `all` method does not rewrite the path headers, so we have to manually set the URL here.
 :::
 
 ```ts [index.ts]
@@ -86,7 +86,7 @@ import { Pool } from 'pg'
 
 // MUST MATCH! Or social login may break with 404 errors.
 export const auth = betterAuth({
-    basePath: '/v1/auth*' // [!code ++]
+    basePath: '/v1/auth' // [!code ++]
 })
 ```
 


### PR DESCRIPTION
this PR fixes the 404 social callback issue mentioned in #576.

also fixed lifecycle error not triggering while mounting to root.

The `mount` will automatically pass errors to the Better Auth handlers, causing all request to return plain 404 rather than predefined lifecycle errors in onError hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Better Auth docs with revised routing recommendations (use route-wide handlers) and updated examples.
  * Clarified URL/basePath configuration, custom endpoint prefixing, and corresponding access URLs to avoid 404s.
  * Added note that the new routing preserves OAuth callback behavior but does not rewrite path headers, so manual URL/header adjustments may be needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->