### PR TITLE
📘 doc: fix typo

### DIFF
--- a/docs/migrate/from-hono.md
+++ b/docs/migrate/from-hono.md
@@ -57,7 +57,7 @@ Here's a TLDR comparison between Hono and Elysia to help you decide:
 - Sounds type safety across the board, including middleware, and error handling
 - Somewhat similar to Fastify in terms of middleware, encapsulation, and plugin style
 
-There is a huge **different between being compatible and specifically built for** something.
+There is a huge **difference between being compatible and specifically built for** something.
 
 If you decide to use Elysia on Cloudflare Workers, you might miss some of the Cloudflare specific features that Hono provides out of the box. Similarly, if you use Hono on Bun, you might not get the best performance possible compared to using Elysia.
 


### PR DESCRIPTION
Fix typo in the Hono migration doc. 
PS: I hate making Readme changes, especially if they are this small, but it was triggering my OCD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammatical error in migration guide for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->