### PR TITLE
:wrench: fix: clamp time display to 0-100% to prevent negative ms values

### DIFF
--- a/docs/components/fern/beyond.vue
+++ b/docs/components/fern/beyond.vue
@@ -168,7 +168,7 @@ function move(event: MouseEvent) {
 
     const _left = (mouseX / rect.width) * 100
 
-    left.value = _left
+    left.value = Math.max(0, Math.min(100, _left))
 }
 </script>
 


### PR DESCRIPTION
When mouse moves outside the left edge of the OpenTelemetry timeline, the displayed time could show negative values (e.g. -0.03ms). Clamp left percentage to [0, 100] range so time always displays 0ms-25ms.

<img width="517" height="298" alt="image" src="https://github.com/user-attachments/assets/4424d722-90de-418b-95ad-bd8d66700576" />

After:

<img width="512" height="295" alt="image" src="https://github.com/user-attachments/assets/ce7945b4-9f59-4032-bd88-bfca33787b57" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the left position could exceed valid bounds, ensuring it now stays within the acceptable range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->