### PR TITLE
Fix error in example code for Best Practice page

### DIFF
--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -138,7 +138,7 @@ import type { AuthModel } from './model'
 // If a class doesn't need to store a property,
 // you can use an `abstract class` to avoid class allocation
 export abstract class Auth {
-	static async signIn({ username, password }: AuthModel.signInBody) {
+	static async signIn({ username, password }: AuthModel['signInBody']) {
 		const user = await sql`
 			SELECT password
 			FROM users
@@ -149,7 +149,7 @@ export abstract class Auth {
 			// You can throw an HTTP error directly
 			throw status(
 				400,
-				'Invalid username or password' satisfies AuthModel.signInInvalid
+				'Invalid username or password' satisfies AuthModel['signInInvalid']
 			)
 
 		return {
@@ -164,7 +164,7 @@ export abstract class Auth {
 // Model define the data structure and validation for the request and response
 import { t, type UnwrapSchema } from 'elysia'
 
-const AuthModel = {
+export const AuthModel = {
 	signInBody: t.Object({
 		username: t.String(),
 		password: t.String(),


### PR DESCRIPTION
Due to the previous removal of namespaces from the example folder structure, new errors arose in the service and controller files, which have been fixed.
https://elysiajs.com/essential/best-practice.html#folder-structure

Not sure if accessing types like `AuthModel["signInBody"]` is the preferred approach though — happy to hear any thoughts.