### PR TITLE
Add project templates section to overview.md

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -138,6 +138,10 @@ Here are some of the official plugins maintained by the Elysia team:
 
 -   [prismabox](https://github.com/m1212e/prismabox) - Generator for TypeBox schemas based on your database models, works well with Elysia
 
+## Project templates:
+
+-   [ElysiaTemplate](https://github.com/QLing-yes/ElysiaTemplate) - MVC backend, auto route & middleware, more coming.
+
 ---
 
 If you have a plugin written for Elysia, feel free to add your plugin to the list by **clicking <i>Edit this page on GitHub</i>** below 👇


### PR DESCRIPTION
Added a section for project templates with ElysiaTemplate link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Project templates section to plugin overview documentation
  * Included ElysiaTemplate as a referenced resource for project template discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->