### PR TITLE
fix: update idleTimeout default from 10s to 30s

### DIFF
--- a/docs/patterns/configuration.md
+++ b/docs/patterns/configuration.md
@@ -373,13 +373,13 @@ import { Elysia } from 'elysia'
 
 new Elysia({
 	serve: {
-		// Increase idle timeout to 30 seconds
-		idleTimeout: 30
+		// Increase idle timeout to 60 seconds
+		idleTimeout: 60
 	}
 })
 ```
 
-By default the idle timeout is 10 seconds (on Bun).
+By default the idle timeout is 30 seconds.
 
 ---
 
@@ -401,9 +401,9 @@ Uniquely identify a server instance with an ID
 This string will be used to hot reload the server without interrupting pending requests or websockets. If not provided, a value will be generated. To disable hot reloading, set this value to `null`.
 
 ### serve.idleTimeout
-@default `10` (10 seconds)
+@default `30` (30 seconds)
 
-By default, Bun sets idle timeout to 10 seconds, which means that if a request is not completed within 10 seconds, it will be aborted.
+By default, Elysia sets idle timeout to 30 seconds, which means that if a request is not completed within 30 seconds, it will be aborted.
 
 ### serve.maxRequestBodySize
 @default `1024 * 1024 * 128` (128MB)


### PR DESCRIPTION
## Summary
- Updates documentation to reflect that Elysia's default `idleTimeout` is **30 seconds**, not 10 seconds
- The default was changed in Elysia v1.3.9 ([commit 3b3700a](https://github.com/elysiajs/elysia/commit/3b3700abc1d4cc3252399ae554e6530460a049b3)) but the docs were never updated
- Updates the code example to use 60s instead of 30s so it actually demonstrates increasing the timeout

Fixes elysiajs/elysia#1770

Context: PR [elysiajs/elysia#1786](https://github.com/elysiajs/elysia/pull/1786) attempted to change the code default back to 10s, but SaltyAom [decided to keep 30s](https://github.com/elysiajs/elysia/pull/1786#issuecomment-2714221795) and fix the docs instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated idle timeout configuration documentation with revised default values and examples.
  * Code samples and configuration guides now reflect the current idle timeout defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->