### PR TITLE
Fix discrepancy in Coercion example

### DIFF
--- a/docs/essential/validation.md
+++ b/docs/essential/validation.md
@@ -402,7 +402,7 @@ new Elysia()
 
 
 		query: t.Object({ // [!code ++]
-			name: t.Number() // [!code ++]
+			id: t.Number() // [!code ++]
 		}) // [!code ++]
 	})
 	.listen(3000)

--- a/docs/essential/validation.md
+++ b/docs/essential/validation.md
@@ -48,7 +48,7 @@ const demo2 = new Elysia()
 const demo3 = new Elysia()
  	.guard({
         query: t.Object({
-            name: t.Number()
+            id: t.Number()
         })
     })
     .get('/query?id=1', ({ query: { id } }) => id)


### PR DESCRIPTION
In the **Coercion** section, the code block expects a `name` query parameter as number (t.Number()), but the browser preview shows `?id=1` as the correct example and `?id=salt` as the incorrect one. This causes a type mismatch, which is confusing for users trying to understand how coercion works.

Suggested fix: Changed the validation key from `name` to `id`, so the two examples are correct.

<img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/af4f65c3-2927-42d2-bff9-636075de6170" />
<img width="3072" height="1728" alt="Screenshot from 2026-03-30 23-02-26" src="https://github.com/user-attachments/assets/6d1c86f8-2208-4af1-9743-696381dce2b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated validation examples to use the `id` query parameter and aligned the related example snippets and playground guidance accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->