### PR TITLE
docs(prisma): update integration for Prisma v7

### DIFF
--- a/docs/integrations/prisma.md
+++ b/docs/integrations/prisma.md
@@ -97,17 +97,6 @@ model Post {
 }
 ```
 
-```ts [prisma.config.ts]
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
 :::
 
 This will generate Elysia validation models in the `generated/prismabox` directory.

--- a/docs/integrations/prisma.md
+++ b/docs/integrations/prisma.md
@@ -69,7 +69,8 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  // Note: In Prisma 7+, the URL is passed via adapter in PrismaClient constructor
+  // Note: In Prisma 7+, datasource URL is configured in prisma.config.ts (for Prisma CLI),
+  // and when using driver adapters you also pass the runtime URL in adapter setup.
 }
 
 generator prismabox { // [!code ++]

--- a/docs/integrations/prisma.md
+++ b/docs/integrations/prisma.md
@@ -50,7 +50,7 @@ We can use Prismabox to convert Prisma schema into Elysia validation models, whi
 To install Prisma, run the following command:
 
 ```bash
-bun add @prisma/client prismabox && \
+bun add @prisma/client prismabox prisma-adapter-bun-sqlite && \
 bun add -d prisma
 ```
 
@@ -69,7 +69,7 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
+  // Note: In Prisma 7+, the URL is passed via adapter in PrismaClient constructor
 }
 
 generator prismabox { // [!code ++]
@@ -97,6 +97,17 @@ model Post {
 }
 ```
 
+```ts [prisma.config.ts]
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
 :::
 
 This will generate Elysia validation models in the `generated/prismabox` directory.
@@ -115,10 +126,12 @@ Then we can import the generated models in our Elysia application:
 ```ts [src/index.ts]
 import { Elysia, t } from 'elysia'
 
-import { PrismaClient } from '../generated/prisma' // [!code ++]
+import { PrismaBunSqlite } from 'prisma-adapter-bun-sqlite';
+import { PrismaClient } from '../generated/prisma/client' // [!code ++]
 import { UserPlain, UserPlainInputCreate } from '../generated/prismabox/User' // [!code ++]
 
-const prisma = new PrismaClient()
+const adapter = new PrismaBunSqlite({ url: process.env.DATABASE_URL || "file:./dev.db" });
+export const prisma = new PrismaClient({ adapter });
 
 const app = new Elysia()
     .put(

--- a/docs/integrations/prisma.md
+++ b/docs/integrations/prisma.md
@@ -120,7 +120,7 @@ import { PrismaBunSqlite } from 'prisma-adapter-bun-sqlite';
 import { PrismaClient } from '../generated/prisma/client' // [!code ++]
 import { UserPlain, UserPlainInputCreate } from '../generated/prismabox/User' // [!code ++]
 
-const adapter = new PrismaBunSqlite({ url: process.env.DATABASE_URL || "file:./dev.db" });
+const adapter = new PrismaBunSqlite({ url: process.env.DATABASE_URL });
 export const prisma = new PrismaClient({ adapter });
 
 const app = new Elysia()


### PR DESCRIPTION
Hey, just updated the Prisma integration to v7
For reference: https://www.prisma.io/docs/guides/upgrade-prisma-orm/v7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma integration guide: added Bun SQLite adapter installation and setup, clarified Prisma 7+ URL/adapter-driven runtime URL behavior, and revised the example to demonstrate creating and exporting a client configured with an adapter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->