### PR TITLE
fix(docs): update fetch wrapper reference from $fetch to fetch

### DIFF
--- a/docs/eden/treaty/parameters.md
+++ b/docs/eden/treaty/parameters.md
@@ -115,7 +115,7 @@ api.user.post(null, {
 
 ## Fetch parameters
 
-Eden Treaty is a fetch wrapper; we may add any valid [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) parameters to Eden by passing them to `$fetch`:
+Eden Treaty is a fetch wrapper; we may add any valid [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) parameters to Eden by passing them to `fetch`:
 
 ```typescript
 import { Elysia, t } from 'elysia'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parameter documentation to clarify passing Fetch API options to the correct function when configuring Eden Treaty fetch parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->