### PR TITLE
docs: add elysia-mcp community plugin

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -44,7 +44,6 @@ Here are some of the official plugins maintained by the Elysia team:
 ## Community plugins
 
 -   [Create ElysiaJS](https://github.com/kravetsone/create-elysiajs) - scaffold your Elysia project with the environment easily (help with ORM, Linters and Plugins)!
--   [@8monkey/elysia-mcp](https://github.com/8monkey-ai/elysia-mcp) - turn existing Elysia routes into MCP tools without duplicating schemas or handlers.
 -   [Lucia Auth](https://github.com/pilcrowOnPaper/lucia) - authentication that is simple and clean
 -   [Elysia Clerk](https://github.com/wobsoriano/elysia-clerk) - unofficial Clerk authentication plugin
 -   [Elysia Polyfills](https://github.com/bogeychan/elysia-polyfills) - run Elysia ecosystem on Node.js and Deno
@@ -63,6 +62,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [Elysia OpenID Client](https://github.com/macropygia/elysia-openid-client) - OpenID client based on [openid-client](https://github.com/panva/node-openid-client)
 -   [Rate Limit](https://github.com/rayriffy/elysia-rate-limit) - simple, lightweight rate limiter
 -   [LLMs.txt](https://github.com/opuu/elysia-llms-txt) - generate `/llms.txt` for LLM-friendly docs from OpenAPI/Swagger
+-   [Elysia MCP](https://github.com/8monkey-ai/elysia-mcp) - turn existing Elysia routes into MCP tools without duplicating schemas or handlers.
 -   [Logysia](https://github.com/tristanisham/logysia) - classic logging middleware
 -   [Logestic](https://github.com/cybercoder-naj/logestic) - an advanced and customizable logging library for ElysiaJS
 -   [Logger](https://github.com/bogeychan/elysia-logger) - [pino](https://github.com/pinojs/pino)-based logging middleware

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -44,6 +44,7 @@ Here are some of the official plugins maintained by the Elysia team:
 ## Community plugins
 
 -   [Create ElysiaJS](https://github.com/kravetsone/create-elysiajs) - scaffold your Elysia project with the environment easily (help with ORM, Linters and Plugins)!
+-   [@8monkey/elysia-mcp](https://github.com/8monkey-ai/elysia-mcp) - turn existing Elysia routes into MCP tools without duplicating schemas or handlers.
 -   [Lucia Auth](https://github.com/pilcrowOnPaper/lucia) - authentication that is simple and clean
 -   [Elysia Clerk](https://github.com/wobsoriano/elysia-clerk) - unofficial Clerk authentication plugin
 -   [Elysia Polyfills](https://github.com/bogeychan/elysia-polyfills) - run Elysia ecosystem on Node.js and Deno

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -62,7 +62,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [Elysia OpenID Client](https://github.com/macropygia/elysia-openid-client) - OpenID client based on [openid-client](https://github.com/panva/node-openid-client)
 -   [Rate Limit](https://github.com/rayriffy/elysia-rate-limit) - simple, lightweight rate limiter
 -   [LLMs.txt](https://github.com/opuu/elysia-llms-txt) - generate `/llms.txt` for LLM-friendly docs from OpenAPI/Swagger
--   [Elysia MCP](https://github.com/8monkey-ai/elysia-mcp) - turn existing Elysia routes into MCP tools without duplicating schemas or handlers.
+-   [Elysia MCP](https://github.com/8monkey-ai/elysia-mcp) - turn existing Elysia routes into MCP tools without duplicating schemas or handlers
 -   [Logysia](https://github.com/tristanisham/logysia) - classic logging middleware
 -   [Logestic](https://github.com/cybercoder-naj/logestic) - an advanced and customizable logging library for ElysiaJS
 -   [Logger](https://github.com/bogeychan/elysia-logger) - [pino](https://github.com/pinojs/pino)-based logging middleware


### PR DESCRIPTION
## Documentation
Added "elysia-mcp" to the community plugins documentation: turn existing Elysia routes into MCP tools without duplicating schemas or handlers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Elysia MCP community plugin to the plugins overview, which converts existing Elysia routes into MCP tools without duplicating schemas or handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->