### PR TITLE
docs: add missing bunFullstack option to fullstack dev server guide

### DIFF
--- a/docs/patterns/fullstack-dev-server.md
+++ b/docs/patterns/fullstack-dev-server.md
@@ -35,7 +35,9 @@ import { Elysia } from 'elysia'
 import { staticPlugin } from '@elysiajs/static'
 
 new Elysia()
-	.use(await staticPlugin()) // [!code ++]
+	.use(await staticPlugin({ // [!code ++]
+		bunFullstack: true // [!code ++]
+	})) // [!code ++]
 	.listen(3000)
 ```
 
@@ -43,6 +45,12 @@ new Elysia()
 Notice that we need to add `await` before `staticPlugin()` to enable Fullstack Dev Server.
 
 This is required to setup the necessary HMR hooks.
+:::
+
+:::warning
+You also need to pass `bunFullstack: true` option to `staticPlugin()` to enable Bun's HTML bundler.
+
+Without it, `.tsx` files referenced in your HTML are served as raw text, causing the browser to throw `SyntaxError`.
 :::
 
 2. Create **public/index.html** and **index.tsx**
@@ -116,7 +124,8 @@ import { staticPlugin } from '@elysiajs/static'
 new Elysia()
   	.use(
   		await staticPlugin({
-  			prefix: '/' // [!code ++]
+  			prefix: '/', // [!code ++]
+  			bunFullstack: true
    		})
    )
   .listen(3000)


### PR DESCRIPTION
Hi guys! Thank you for your good job with Elysia I'm really enjoying the framework, unfortunately i had an issue when testing the fullstack dev server. 2 days ago an option in @elysiajs/static was renamed from bundleHTML to bunFullstack and its default was changed from `true`to `false` ([elysiajs/elysia-static@a1d0dcf](https://github.com/elysiajs/elysia-static/commit/a1d0dcf73e885c9ecb3cdb9db6d4a89f53ea4ea5)), and this is not reflected in the Elysia pattern docs. Since this option toggles Bun's HTML bundler, it must be explicitly set to true so `.jsx`/`.tsx` files are bundled correctly. Without it, `.jsx`/`.tsx` files are served as raw text and the browser throws `SyntaxError`.

With that said, i'd like to give a little help in maintaining the docs up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fullstack development server documentation with clarification on required configuration option for HTML bundling
  * Added warning callout regarding potential syntax errors when the required setting is omitted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->