### PR TITLE
docs(best-practices): fix incorrect GET example using body in sign-in…

### DIFF
--- a/docs/essential/best-practice.md
+++ b/docs/essential/best-practice.md
@@ -108,7 +108,7 @@ import { Auth } from './service'
 import { AuthModel } from './model'
 
 export const auth = new Elysia({ prefix: '/auth' })
-	.get(
+	.post(
 		'/sign-in',
 		async ({ body, cookie: { session } }) => {
 			const response = await Auth.signIn(body)


### PR DESCRIPTION
## Description

While going through the Best Practices section (folder structure), I noticed a small inconsistency in the example:

The `/sign-in` route is defined as a `GET` request, but its schema includes a `body`. Since `GET` requests typically don’t have a request body, this can be a bit confusing for readers.

This PR updates the example to use `POST`, which better matches the intended usage.

## Changes

- Switched `/sign-in` route method from `GET` to `POST`
- Kept the rest of the example unchanged

## Why it matters

This helps avoid confusion for developers who are learning from the docs and aligns the example with common HTTP practices.

Thanks for the awesome work on the docs!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated best-practice examples for authentication endpoints to use the POST method for sign-in operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->