### PR TITLE
Fix default value for config.aot

### DIFF
--- a/docs/patterns/configuration.md
+++ b/docs/patterns/configuration.md
@@ -87,7 +87,7 @@ new Elysia({
 ```
 Disable Ahead of Time compilation
 
-#### Options - @default `false`
+#### Options - @default `true`
 
 - `true` - Precompile every route before starting the server
 


### PR DESCRIPTION
Right now, the default value for **aot** in the config is set to `false` (https://elysiajs.com/patterns/configuration#aot). This PR changes the default value to `true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default value documentation for the AOT configuration option from false to true.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->