### PR TITLE
docs: fix typo in file extension

### DIFF
--- a/docs/essential/handler.md
+++ b/docs/essential/handler.md
@@ -285,7 +285,7 @@ import { Elysia, form, file } from 'elysia'
 new Elysia()
 	.get('/', () => form({
 		name: 'Tea Party',
-		images: [file('nagi.web'), file('mika.webp')]
+		images: [file('nagi.webp'), file('mika.webp')]
 	}))
 	.listen(3000)
 ```
@@ -299,7 +299,7 @@ Or alternatively, you can return a single file by returning `file` directly with
 import { Elysia, file } from 'elysia'
 
 new Elysia()
-	.get('/', file('nagi.web'))
+	.get('/', file('nagi.webp'))
 	.listen(3000)
 ```
 


### PR DESCRIPTION
I noticed the line `images: [file('nagi.web'), file('mika.webp')]` in the docs [_Handler_](https://elysiajs.com/essential/handler.html#formdata) page. I looks like a type and that it is supposed to be `'nagi.webp'` for the image format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Corrected file references in handler documentation examples to reflect accurate file names in code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->