### PR TITLE
docs: Add Elysia FSR plugin to overview documentation

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -74,7 +74,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [Apitally](https://github.com/apitally/apitally-js) - capture metrics, logs, and traces in [Apitally](https://apitally.io/elysia), a simple API monitoring and analytics tool
 -   [Elysia Lambda](https://github.com/TotalTechGeek/elysia-lambda) - deploy on AWS Lambda
 -   [Decorators](https://github.com/gaurishhs/elysia-decorators) - use TypeScript decorators
--   [Elysia FSR](https://github.com/deadlinecode/elysia-fsr) - a file system based router for elysia with generated eden compatible route types and support for monorepos/workspaces, ghost routes and more! (also creates a correct file tree matching call stack)
+-   [Elysia FSR](https://github.com/deadlinecode/elysia-fsr) - file-system routing with Eden-compatible type generation, monorepo/workspace support, and logical route grouping
 -   [Autoload](https://github.com/kravetsone/elysia-autoload) - filesystem router based on a directory structure that generates types for [Eden](/eden/overview) with [`Bun.build`](https://github.com/kravetsone/elysia-autoload?tab=readme-ov-file#bun-build-usage) support
 -   [Msgpack](https://github.com/kravetsone/elysia-msgpack) - allows you to work with [MessagePack](https://msgpack.org)
 -   [XML](https://github.com/kravetsone/elysia-xml) - allows you to work with XML

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -74,6 +74,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [Apitally](https://github.com/apitally/apitally-js) - capture metrics, logs, and traces in [Apitally](https://apitally.io/elysia), a simple API monitoring and analytics tool
 -   [Elysia Lambda](https://github.com/TotalTechGeek/elysia-lambda) - deploy on AWS Lambda
 -   [Decorators](https://github.com/gaurishhs/elysia-decorators) - use TypeScript decorators
+-   [Elysia FSR](https://github.com/deadlinecode/elysia-fsr) - a file system based router for elysia with generated eden compatible route types and support for monorepos/workspaces, ghost routes and more! (also creates a correct file tree matching call stack)
 -   [Autoload](https://github.com/kravetsone/elysia-autoload) - filesystem router based on a directory structure that generates types for [Eden](/eden/overview) with [`Bun.build`](https://github.com/kravetsone/elysia-autoload?tab=readme-ov-file#bun-build-usage) support
 -   [Msgpack](https://github.com/kravetsone/elysia-msgpack) - allows you to work with [MessagePack](https://msgpack.org)
 -   [XML](https://github.com/kravetsone/elysia-xml) - allows you to work with XML


### PR DESCRIPTION
Hiiiii :3

i made a cool little package for file system routing. Since all the other file system router packages seem to be out of date (not actively maintained) i thought i create my own package [elysia-fsr](https://github.com/deadlinecode/elysia-fsr).

It not only features the default file routing everyone already knows and loves but also cool stuff like:
- eden type gen
- a lot of useful logging to debug the file tree
- unit tests for not only runtime stuff but also e2e eden type tests (very proud of this owo)
- a lot of options for type gen and with it support for monorepos/workspaces, ghost routes and a correct file tree matching call stack meaning it does logical grouping correctly based on the file tree so you can guard folders (i know i sound like a sellout lmao)

I would be soooo happy if this could get merged into the docs :0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Elysia FSR to community plugins: introduces file-system routing, Eden-compatible route type generation, monorepo/workspace support, and logical route grouping for easier integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/documentation/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->