### PR TITLE
Add theme switch overlay transition

### DIFF
--- a/docs/.vitepress/theme/layout.vue
+++ b/docs/.vitepress/theme/layout.vue
@@ -53,11 +53,26 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
 
     window.localStorage.setItem('theme-switch', Date.now().toString())
 
-    if (document.startViewTransition !== undefined)
-        await document.startViewTransition(async () => {
+    const root = document.documentElement
+    root.classList.add('-theme-switching')
+    root.classList.toggle(
+        '-theme-switching-from-dark',
+        root.classList.contains('dark')
+    )
+
+    if (document.startViewTransition !== undefined) {
+        const transition = document.startViewTransition(async () => {
             darkTheme.value = !darkTheme.value
             await nextTick()
-        }).ready
+        })
+
+        void transition.finished.finally(() => {
+            root.classList.remove('-theme-switching')
+            root.classList.remove('-theme-switching-from-dark')
+        })
+
+        await transition.ready
+    }
 })
 
 const onNewPage = () => {
@@ -124,6 +139,8 @@ function toggleAIForCurrentPage() {
 </script>
 
 <template>
+    <div class="theme-switch-overlay" aria-hidden="true" />
+
     <DefaultTheme.Layout>
         <template #doc-top>
             <Ray

--- a/docs/tailwind.css
+++ b/docs/tailwind.css
@@ -207,7 +207,40 @@ body {
 
 ::view-transition-group(root) {
     animation-timing-function: var(--expo-in);
-    z-index: 100;
+    z-index: 1000;
+}
+
+.theme-switch-overlay {
+    position: fixed;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+}
+
+html.-theme-switching .theme-switch-overlay {
+    view-transition-name: theme-switch-overlay;
+}
+
+::view-transition-group(theme-switch-overlay) {
+    z-index: 1001;
+}
+
+::view-transition-old(theme-switch-overlay) {
+    display: none;
+}
+
+::view-transition-new(theme-switch-overlay) {
+    mask: url('/assets/shigure-ui-smol.gif') center / 0 no-repeat;
+    animation: theme-switch-overlay var(--switch-duration) both;
+    mix-blend-mode: normal;
+}
+
+html.-theme-switching-from-dark::view-transition-new(theme-switch-overlay) {
+    background: white;
+}
+
+html.-theme-switching:not(.-theme-switching-from-dark)::view-transition-new(theme-switch-overlay) {
+    background: black;
 }
 
 ::view-transition-new(root) {
@@ -251,6 +284,24 @@ body {
     }
     100% {
         mask-size: 750vmax;
+    }
+}
+
+@keyframes theme-switch-overlay {
+    0% {
+        mask-size: 0;
+        opacity: 1;
+    }
+
+    10%,
+    90% {
+        mask-size: 25vmax;
+        opacity: 1;
+    }
+
+    100% {
+        mask-size: 25vmax;
+        opacity: 0;
     }
 }
 

--- a/docs/tailwind.css
+++ b/docs/tailwind.css
@@ -207,7 +207,7 @@ body {
 
 ::view-transition-group(root) {
     animation-timing-function: var(--expo-in);
-    z-index: 1000;
+    z-index: 100;
 }
 
 .theme-switch-overlay {
@@ -222,7 +222,7 @@ html.-theme-switching .theme-switch-overlay {
 }
 
 ::view-transition-group(theme-switch-overlay) {
-    z-index: 1001;
+    z-index: 101;
 }
 
 ::view-transition-old(theme-switch-overlay) {


### PR DESCRIPTION
## What
Adds a masked overlay animation when switching between light and dark themes.
Closes #849

## Changes
- Add a dedicated theme switch overlay element
- Apply a named View Transition to the overlay
- Clean up temporary theme switching classes after the transition finishes

Note: This PR was drafted with AI assistance and reviewed by me before submission.