### PR TITLE
Update static plugin configuration for React docs

### DIFF
--- a/docs/patterns/fullstack-dev-server.md
+++ b/docs/patterns/fullstack-dev-server.md
@@ -35,7 +35,9 @@ import { Elysia } from 'elysia'
 import { staticPlugin } from '@elysia/static'
 
 new Elysia()
-	.use(await staticPlugin()) // [!code ++]
+	.use(await staticPlugin({ // [!code ++]
+		bunFullstack: true // [!code ++]
+	})) // [!code ++]
 	.listen(3000)
 ```
 
@@ -43,6 +45,10 @@ new Elysia()
 Notice that we need to add `await` before `staticPlugin()` to enable Fullstack Dev Server.
 
 This is required to setup the necessary HMR hooks.
+:::
+
+:::tip
+You need to set `bunFullstack` parameter to `true` to use React.
 :::
 
 2. Create **public/index.html** and **index.tsx**
@@ -116,7 +122,8 @@ import { staticPlugin } from '@elysia/static'
 new Elysia()
   	.use(
   		await staticPlugin({
-  			prefix: '/' // [!code ++]
+  			prefix: '/', // [!code ++]
+			bunFullstack: true [!code++]
    		})
    )
   .listen(3000)


### PR DESCRIPTION
The 'bunFullstack' parameter wasn't present in the docs causing the browser to throw issue parsing React code.

I've added the `bunFullstack` parameter to the docs so that React can be rendered properly.

Without this parameter, React doesn't render at all but instead throws an error in the browser console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fullstack Dev Server documentation with clearer React configuration guidance. Added explicit instructions for required settings to enable React support in Bun's development environment, including configuration examples for both standard and custom file serving paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->