### PR TITLE
Add Elysia Starter template to project templates

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -147,7 +147,7 @@ Here are some of the official plugins maintained by the Elysia team:
 ## Project templates:
 
 -   [ElysiaTemplate](https://github.com/QLing-yes/ElysiaTemplate) - MVC backend, auto route & middleware, more coming.
--   [Kavoru](https://github.com/mertthesamael/Kavoru) A production-ready ElysiaJS backend starter on Bun and TypeScript, with JWT auth, Prisma/PostgreSQL, OpenAPI, OpenTelemetry, Sentry, Kafka, WebSockets, Resend email, cron jobs, and Docker — structured for feature modules and a consistent API response envelope.
+-   [Kavoru](https://github.com/mertthesamael/Kavoru) - A production-ready ElysiaJS backend starter on Bun and TypeScript, with JWT auth, Prisma/PostgreSQL, OpenAPI, OpenTelemetry, Sentry, Kafka, WebSockets, Resend email, cron jobs, and Docker — structured for feature modules and a consistent API response envelope.
 
 ---
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -147,6 +147,7 @@ Here are some of the official plugins maintained by the Elysia team:
 ## Project templates:
 
 -   [ElysiaTemplate](https://github.com/QLing-yes/ElysiaTemplate) - MVC backend, auto route & middleware, more coming.
+-   [Kavoru]([https://github.com/QLing-yes/ElysiaTemplate](https://github.com/mertthesamael/Kavoru)) A production-ready ElysiaJS backend starter on Bun and TypeScript, with JWT auth, Prisma/PostgreSQL, OpenAPI, OpenTelemetry, Sentry, Kafka, WebSockets, Resend email, cron jobs, and Docker — structured for feature modules and a consistent API response envelope.
 
 ---
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -147,7 +147,7 @@ Here are some of the official plugins maintained by the Elysia team:
 ## Project templates:
 
 -   [ElysiaTemplate](https://github.com/QLing-yes/ElysiaTemplate) - MVC backend, auto route & middleware, more coming.
--   [Kavoru]([https://github.com/QLing-yes/ElysiaTemplate](https://github.com/mertthesamael/Kavoru)) A production-ready ElysiaJS backend starter on Bun and TypeScript, with JWT auth, Prisma/PostgreSQL, OpenAPI, OpenTelemetry, Sentry, Kafka, WebSockets, Resend email, cron jobs, and Docker — structured for feature modules and a consistent API response envelope.
+-   [Kavoru](https://github.com/mertthesamael/Kavoru) A production-ready ElysiaJS backend starter on Bun and TypeScript, with JWT auth, Prisma/PostgreSQL, OpenAPI, OpenTelemetry, Sentry, Kafka, WebSockets, Resend email, cron jobs, and Docker — structured for feature modules and a consistent API response envelope.
 
 ---
 


### PR DESCRIPTION
A production-ready ElysiaJS backend starter on Bun and TypeScript, with JWT auth, Prisma/PostgreSQL, OpenAPI, OpenTelemetry, Sentry, Kafka, WebSockets, Resend email, cron jobs, and Docker — structured for feature modules and a consistent API response envelope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Kavoru to the community project templates list — a production-ready ElysiaJS backend starter (Bun/TypeScript) with JWT auth, Prisma/PostgreSQL, OpenAPI, OpenTelemetry, Sentry, Kafka, WebSockets, Resend email, cron job examples, and Docker support. Includes a link and concise description to help users discover and evaluate this starter for quickly scaffolding production-oriented backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->