### PR TITLE
docs: fix typo in model refactoring example

### DIFF
--- a/docs/tutorial/features/openapi/index.md
+++ b/docs/tutorial/features/openapi/index.md
@@ -99,7 +99,7 @@ new Elysia()
 		'/',
 		({ body }) => body,
 		{
-			age: t.Object({ // [!code --]
+			body: t.Object({ // [!code --]
 				age: t.Number() // [!code --]
 			}), // [!code --]
 			body: 'age',  // [!code ++]


### PR DESCRIPTION
Fixes a typo in the model refactoring example. The inline validation block incorrectly used `age:` as the schema key instead of `body:`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenAPI tutorial example so the request body schema now uses `body` instead of `age` in the reference model example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->