### PR TITLE
docs: add @stitchapi/elysia community plugin

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -139,6 +139,7 @@ Here are some of the official plugins maintained by the Elysia team:
 -   [elysia-wide-event](https://github.com/choiexe1/elysia-wide-event) - Wide event logging plugin for structured request-level observability.
 - [elysia-beta-headers](https://github.com/P0u4a/elysia-beta-headers) - Elysia plugin for gating your app's beta/experimental features via type-safe API headers
 -   [elysia-better-session](https://github.com/0x0arash/elysia-better-session) - Elysia plugin for server-side session management with different store adapters.
+-   [@stitchapi/elysia](https://github.com/rejifald/StitchAPI/tree/main/packages/elysia) - Plugin that adds a StitchAPI seam to the context for typed outbound API calls, with per-request principal, SSE streaming, and error-to-HTTP mapping.
 
 ## Complementary projects:
 


### PR DESCRIPTION
Adds [@stitchapi/elysia](https://github.com/rejifald/StitchAPI/tree/main/packages/elysia) to the Community plugins list.

It's an Elysia plugin for [StitchAPI](https://stitchapi.dev): `.use()` it and every request gets a `stitch` seam on its context for typed, validated outbound API calls, scoped to a per-request principal. It also bridges into Elysia's Web-standard world — SSE streaming and a stitch-error → HTTP status mapping. Fetch-only, no `node:*`, so it runs on Bun, Node, Deno and the edge.

- npm: https://www.npmjs.com/package/@stitchapi/elysia
- source: https://github.com/rejifald/StitchAPI/tree/main/packages/elysia

Appended to the end of the Community plugins section, matching the existing entry format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the community plugins list with a new entry for `@stitchapi/elysia`.
  * Added a brief description of its supported capabilities, including typed API calls, per-request context, streaming, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->