### PR TITLE
fix: designed-for-typo on landing page

### DIFF
--- a/docs/components/fern/ssot.vue
+++ b/docs/components/fern/ssot.vue
@@ -14,7 +14,7 @@
                 <span class="text-black dark:text-white"
                     >request validation, type inference, OpenAPI documentation,
                     client-server communication</span
-                >. Every part of Elysia is design for
+                >. Every part of Elysia is designed for
                 <span
                     class="font-bold text-gradient from-lime-400 to-sky-400 leading-tight"
                 >


### PR DESCRIPTION
Fixes one sentence on the landing page:

> Every part of Elysia is design**ed** for complete type integrity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a grammar error in the “Single Source of Truth” description for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->