### PR TITLE
fix(docs): correct server import path in landing page Eden Treaty example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -231,7 +231,7 @@ export type App = typeof app
 // @filename: client.ts
 // ---cut---
 import { treaty } from '@elysia/eden'
-import type { App } from 'server'
+import type { App } from './server'
 
 const api = treaty<App>('api.elysiajs.com')
 
@@ -437,7 +437,7 @@ export type App = typeof app
 // @filename: client.ts
 // ---cut---
 import { treaty } from '@elysia/eden'
-import type { App } from 'server'
+import type { App } from './server'
 
 const api = treaty<App>('api.elysiajs.com')
 


### PR DESCRIPTION
<img width="2288" height="714" alt="before-after-side-by-side" src="https://github.com/user-attachments/assets/6dc77a5d-d08a-4d91-abc9-c315f55a0041" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated end-to-end and type-safety examples to use the correct relative import path for the `App` component.
  * Applied the correction consistently across both documented examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->