### PR TITLE
docs(plugins): add @mwillbanks/elysia-mcp-adapter

### DIFF
--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -43,6 +43,7 @@ Here are some of the official plugins maintained by the Elysia team:
 
 ## Community plugins
 
+-   [Elysia MCP Adapter](https://mwillbanks.github.io/elysia-mcp-adapter) - Expose APIs as MCP tools, MCP tools, MCP apps without bypassing the framework behavior that makes them production-ready.
 -   [Create ElysiaJS](https://github.com/kravetsone/create-elysiajs) - scaffold your Elysia project with the environment easily (help with ORM, Linters and Plugins)!
 -   [Lucia Auth](https://github.com/pilcrowOnPaper/lucia) - authentication that is simple and clean
 -   [Elysia Clerk](https://github.com/wobsoriano/elysia-clerk) - unofficial Clerk authentication plugin

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -43,7 +43,7 @@ Here are some of the official plugins maintained by the Elysia team:
 
 ## Community plugins
 
--   [Elysia MCP Adapter](https://mwillbanks.github.io/elysia-mcp-adapter) - Expose APIs as MCP tools, MCP tools, MCP apps without bypassing the framework behavior that makes them production-ready.
+-   [Elysia MCP Adapter](https://mwillbanks.github.io/elysia-mcp-adapter) - Expose APIs through MCP, build MCP tools, and MCP apps without bypassing the framework behavior that makes them production-ready.
 -   [Create ElysiaJS](https://github.com/kravetsone/create-elysiajs) - scaffold your Elysia project with the environment easily (help with ORM, Linters and Plugins)!
 -   [Lucia Auth](https://github.com/pilcrowOnPaper/lucia) - authentication that is simple and clean
 -   [Elysia Clerk](https://github.com/wobsoriano/elysia-clerk) - unofficial Clerk authentication plugin


### PR DESCRIPTION
Adds @mwillbanks/elysia-mcp-adapter to the elysia community plugin documentation which enables a suite of mcp related functionality from elysia, utilized most often to expose dual surface API/MCP but also distinct MCP tools, apps and exposes MCP extensions. Works with existing plugins like openapi/opentelemetry and existing lifecycle events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the Elysia MCP Adapter to the community plugins list.
  * Included a link to the project and a brief description of its MCP tool and app exposure capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->