### PR TITLE
fix: update Swagger plugin install to use @elysiajs/swagger

### DIFF
--- a/docs/eden/installation.md
+++ b/docs/eden/installation.md
@@ -125,9 +125,9 @@ node_modules/elysia
   peer elysia@">= 1.1.0" from @elysia/opentelemetry@1.1.2
   node_modules/@elysia/opentelemetry
     dev @elysia/opentelemetry@"1.1.7" from the root project
-  peer elysia@">= 1.1.0" from @elysia/swagger@1.1.0
-  node_modules/@elysia/swagger
-    dev @elysia/swagger@"1.1.6" from the root project
+  peer elysia@">= 1.1.0" from @elysiajs/swagger@1.1.0
+  node_modules/@elysiajs/swagger
+    dev @elysiajs/swagger@"1.1.6" from the root project
   peer elysia@">= 1.1.0" from @elysia/eden@1.1.2
   node_modules/@elysia/eden
     dev @elysia/eden@"1.1.3" from the root project

--- a/docs/migrate/from-fastify.txt
+++ b/docs/migrate/from-fastify.txt
@@ -1223,7 +1223,7 @@ const app = new Elysia()
 
 <template v-slot:right-content>
 
-> Elysia use `@elysia/swagger` for OpenAPI documentation using Scalar by default, or optionally Swagger
+> Elysia use `@elysiajs/swagger` for OpenAPI documentation using Scalar by default, or optionally Swagger
 
 </template>
 

--- a/docs/plugins/openapi.md
+++ b/docs/plugins/openapi.md
@@ -7,11 +7,11 @@ head:
 
     - - meta
       - name: 'description'
-        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysia/swagger".
+        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysiajs/swagger".
 
     - - meta
       - name: 'og:description'
-        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysia/swagger".
+        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysiajs/swagger".
 ---
 
 <script setup lang="ts">

--- a/docs/plugins/swagger.md
+++ b/docs/plugins/swagger.md
@@ -8,11 +8,11 @@ head:
 
     - - meta
       - name: 'description'
-        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysia/swagger".
+        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysiajs/swagger".
 
     - - meta
       - name: 'og:description'
-        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysia/swagger".
+        content: Plugin for Elysia that adds support for generating Swagger API documentation for Elysia Server. Start by installing the plugin with "bun add @elysiajs/swagger".
 ---
 
 ::: warning
@@ -26,7 +26,7 @@ This plugin generates a Swagger endpoint for an Elysia server
 Install with:
 
 ```bash
-bun add @elysia/swagger
+bun add @elysiajs/swagger
 ```
 
 Then use it:

--- a/docs/plugins/swagger.md
+++ b/docs/plugins/swagger.md
@@ -33,7 +33,7 @@ Then use it:
 
 ```typescript
 import { Elysia } from 'elysia'
-import { swagger } from '@elysia/swagger'
+import { swagger } from '@elysiajs/swagger'
 
 new Elysia()
     .use(swagger())
@@ -98,7 +98,7 @@ You can change the swagger endpoint by setting [path](#path) in the plugin confi
 
 ```typescript
 import { Elysia } from 'elysia'
-import { swagger } from '@elysia/swagger'
+import { swagger } from '@elysiajs/swagger'
 
 new Elysia()
     .use(
@@ -113,7 +113,7 @@ new Elysia()
 
 ```typescript
 import { Elysia } from 'elysia'
-import { swagger } from '@elysia/swagger'
+import { swagger } from '@elysiajs/swagger'
 
 new Elysia()
     .use(


### PR DESCRIPTION
Update installation command for Swagger plugin to use @elysiajs/swagger

https://www.npmjs.com/package/@elysiajs/swagger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the Swagger plugin package name in OpenAPI and Swagger documentation metadata.
  * Updated installation instructions and TypeScript import examples to use `@elysiajs/swagger`.
  * Updated package references in dependency-checking and migration examples for consistency.
  * Improved documentation accuracy for users installing or migrating to the Swagger plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->